### PR TITLE
Support unquoted strings, single-quoted strings, and double-quoted strings with relevant escapes

### DIFF
--- a/src/main.zig
+++ b/src/main.zig
@@ -3,6 +3,9 @@ const assert = std.debug.assert;
 const math = std.math;
 const mem = std.mem;
 const testing = std.testing;
+
+pub const log_level: std.log.Level = .debug;
+
 const log = std.log.scoped(.yaml);
 
 const Allocator = mem.Allocator;
@@ -95,7 +98,11 @@ pub const Value = union(ValueType) {
                 return switch (hint) {
                     .int => Value{ .int = try std.fmt.parseInt(i64, raw, 10) },
                     .float => Value{ .float = try std.fmt.parseFloat(f64, raw) },
-                    .string => Value{ .string = try arena.dupe(u8, raw) },
+                    .string => switch (value.escape_mode) {
+                        .None => Value{ .string = try arena.dupe(u8, raw) },
+                        .DoubleQuote => Value{ .string = value.string_value.items },
+                        .SingleQuote => Value{ .string = value.string_value.items },
+                    },
                     else => unreachable,
                 };
             }
@@ -372,6 +379,45 @@ test "typed nested structs" {
     });
     try testing.expect(mem.eql(u8, simple.a.b, "hello there"));
     try testing.expect(mem.eql(u8, simple.a.c, "wait, what?"));
+}
+
+test "single quoted string" {
+    const source =
+        \\- 'hello'
+        \\- 'here''s an escaped quote'
+        \\- 'newlines and tabs\nare not\tsupported'
+    ;
+
+    var yaml = try Yaml.load(testing.allocator, source);
+    defer yaml.deinit();
+
+    const arr = try yaml.parse([3][]const u8);
+    try testing.expectEqual(arr.len, 3);
+    try testing.expect(mem.eql(u8, arr[0], "hello"));
+    try testing.expect(mem.eql(u8, arr[1], "here's an escaped quote"));
+    try testing.expect(mem.eql(u8, arr[2], "newlines and tabs\\nare not\\tsupported"));
+}
+
+test "double quoted string" {
+    const source =
+        \\- "hello"
+        \\- "\"here\" are some escaped quotes"
+        \\- "newlines and tabs\nare\tsupported"
+    ;
+
+    var yaml = try Yaml.load(testing.allocator, source);
+    defer yaml.deinit();
+
+    const arr = try yaml.parse([3][]const u8);
+    try testing.expectEqual(arr.len, 3);
+    try testing.expect(mem.eql(u8, arr[0], "hello"));
+    try testing.expect(mem.eql(u8, arr[1],
+        \\"here" are some escaped quotes
+    ));
+    try testing.expect(mem.eql(u8, arr[2],
+        \\newlines and tabs
+        \\are	supported
+    ));
 }
 
 test "multidoc typed not supported yet" {

--- a/src/main.zig
+++ b/src/main.zig
@@ -4,8 +4,6 @@ const math = std.math;
 const mem = std.mem;
 const testing = std.testing;
 
-pub const log_level: std.log.Level = .debug;
-
 const log = std.log.scoped(.yaml);
 
 const Allocator = mem.Allocator;

--- a/src/main.zig
+++ b/src/main.zig
@@ -3,7 +3,6 @@ const assert = std.debug.assert;
 const math = std.math;
 const mem = std.mem;
 const testing = std.testing;
-
 const log = std.log.scoped(.yaml);
 
 const Allocator = mem.Allocator;
@@ -181,11 +180,6 @@ pub const Value = union(ValueType) {
                     .int => Value{ .int = try std.fmt.parseInt(i64, raw, 10) },
                     .float => Value{ .float = try std.fmt.parseFloat(f64, raw) },
                     .string => Value{ .string = try arena.dupe(u8, value.string_value.items) },
-                    // switch (value.escape_mode) {
-                    //     .None => Value{ .string = try arena.dupe(u8, raw) },
-                    //     .DoubleQuote => Value{ .string = try arena.dupe(u8, value.string_value.items) },
-                    //     .SingleQuote => Value{ .string = try arena.dupe(u8, value.string_value.items) },
-                    // },
                     else => unreachable,
                 };
             }

--- a/src/main.zig
+++ b/src/main.zig
@@ -180,11 +180,12 @@ pub const Value = union(ValueType) {
                 return switch (hint) {
                     .int => Value{ .int = try std.fmt.parseInt(i64, raw, 10) },
                     .float => Value{ .float = try std.fmt.parseFloat(f64, raw) },
-                    .string => switch (value.escape_mode) {
-                        .None => Value{ .string = try arena.dupe(u8, raw) },
-                        .DoubleQuote => Value{ .string = try arena.dupe(u8, value.string_value.items) },
-                        .SingleQuote => Value{ .string = try arena.dupe(u8, value.string_value.items) },
-                    },
+                    .string => Value{ .string = try arena.dupe(u8, value.string_value.items) },
+                    // switch (value.escape_mode) {
+                    //     .None => Value{ .string = try arena.dupe(u8, raw) },
+                    //     .DoubleQuote => Value{ .string = try arena.dupe(u8, value.string_value.items) },
+                    //     .SingleQuote => Value{ .string = try arena.dupe(u8, value.string_value.items) },
+                    // },
                     else => unreachable,
                 };
             }

--- a/src/main.zig
+++ b/src/main.zig
@@ -182,8 +182,8 @@ pub const Value = union(ValueType) {
                     .float => Value{ .float = try std.fmt.parseFloat(f64, raw) },
                     .string => switch (value.escape_mode) {
                         .None => Value{ .string = try arena.dupe(u8, raw) },
-                        .DoubleQuote => Value{ .string = value.string_value.items },
-                        .SingleQuote => Value{ .string = value.string_value.items },
+                        .DoubleQuote => Value{ .string = try arena.dupe(u8, value.string_value.items) },
+                        .SingleQuote => Value{ .string = try arena.dupe(u8, value.string_value.items) },
                     },
                     else => unreachable,
                 };

--- a/src/parse.zig
+++ b/src/parse.zig
@@ -586,19 +586,12 @@ const Parser = struct {
                             break :parse;
                         },
                         .NewLine => return error.UnexpectedToken,
+                        .EscapeSeq => {
+                            try node.string_value.append(self.tree.source[tok.start + 1]);
+                        },
                         else => {
-                            var i: usize = tok.start;
-                            while (i < tok.end) : (i += 1) {
-                                var c = self.tree.source[i];
-                                switch (c) {
-                                    '\'' => {
-                                        try node.string_value.append(c);
-                                        i += 1;
-                                    },
-                                    else => {
-                                        try node.string_value.append(c);
-                                    },
-                                }
+                            for (self.tree.source[tok.start..tok.end]) |c| {
+                                try node.string_value.append(c);
                             }
                         },
                     }
@@ -617,32 +610,23 @@ const Parser = struct {
                             break :parse;
                         },
                         .NewLine => return error.UnexpectedToken,
+                        .EscapeSeq => {
+                            switch (self.tree.source[tok.start + 1]) {
+                                'n' => {
+                                    try node.string_value.append('\n');
+                                },
+                                't' => {
+                                    try node.string_value.append('\t');
+                                },
+                                '"' => {
+                                    try node.string_value.append('"');
+                                },
+                                else => {},
+                            }
+                        },
                         else => {
-                            var i: usize = tok.start;
-                            while (i < tok.end) : (i += 1) {
-                                var c = self.tree.source[i];
-                                switch (c) {
-                                    '\\' => {
-                                        if (i < tok.end) {
-                                            switch (self.tree.source[i + 1]) {
-                                                'n' => {
-                                                    try node.string_value.append('\n');
-                                                },
-                                                't' => {
-                                                    try node.string_value.append('\t');
-                                                },
-                                                '"' => {
-                                                    try node.string_value.append('"');
-                                                },
-                                                else => {},
-                                            }
-                                        }
-                                        i += 1;
-                                    },
-                                    else => {
-                                        try node.string_value.append(c);
-                                    },
-                                }
+                            for (self.tree.source[tok.start..tok.end]) |c| {
+                                try node.string_value.append(c);
                             }
                         },
                     }

--- a/src/parse.zig
+++ b/src/parse.zig
@@ -172,7 +172,6 @@ pub const Node = struct {
         base: Node = Node{ .tag = Tag.value, .tree = undefined },
         start: ?TokenIndex = null,
         end: ?TokenIndex = null,
-        escape_mode: EscapeMode = .None,
         string_value: ArrayList(u8) = undefined,
 
         pub const base_tag: Node.Tag = .value;
@@ -193,12 +192,6 @@ pub const Node = struct {
                 self.base.tree.source[start.start..end.end],
             });
         }
-
-        const EscapeMode = enum {
-            None,
-            SingleQuote,
-            DoubleQuote,
-        };
     };
 };
 
@@ -575,7 +568,6 @@ const Parser = struct {
 
         parse: {
             if (self.eatToken(.SingleQuote)) |_| {
-                node.escape_mode = .SingleQuote;
                 node.start = node.start.? + 1;
                 while (true) {
                     const pos = self.token_it.pos;
@@ -599,7 +591,6 @@ const Parser = struct {
             }
 
             if (self.eatToken(.DoubleQuote)) |_| {
-                node.escape_mode = .DoubleQuote;
                 node.start = node.start.? + 1;
                 while (true) {
                     const pos = self.token_it.pos;

--- a/src/parse.zig
+++ b/src/parse.zig
@@ -645,6 +645,12 @@ const Parser = struct {
                         if (self.token_it.peek()) |peek| {
                             if (peek.id != .Literal) {
                                 node.end = trailing;
+                                const start_token = self.tree.tokens[node.start.?];
+                                const end_token = self.tree.tokens[node.end.?];
+                                const raw = self.tree.source[start_token.start..end_token.end];
+                                for (raw) |c| {
+                                    try node.string_value.append(c);
+                                }
                                 break;
                             }
                         }
@@ -652,6 +658,12 @@ const Parser = struct {
                     else => {
                         self.token_it.seekBy(-1);
                         node.end = self.token_it.pos - 1;
+                        const start_token = self.tree.tokens[node.start.?];
+                        const end_token = self.tree.tokens[node.end.?];
+                        const raw = self.tree.source[start_token.start..end_token.end];
+                        for (raw) |c| {
+                            try node.string_value.append(c);
+                        }
                         break;
                     },
                 }


### PR DESCRIPTION
Took a stab at implementing single and double-quoted strings with a start of supported escapes being handled correctly.

This approach keeps the escapes within the "literal" token and relies on the parser to handle the escapes. Alternatively, we could add "escape sequence" tokens. Maybe we could still do that in the future.

What do you think? @kubkon 