### PR TITLE
Handle unindented lists

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -11,7 +11,6 @@ pub fn build(b: *std.build.Builder) void {
 
     var main_tests = b.addTest("src/main.zig");
     main_tests.setBuildMode(mode);
-    // main_tests.addPackagePath("e2e_tests", "test/test.zig");
 
     var e2e_tests = b.addTest("test/test.zig");
     e2e_tests.setBuildMode(mode);

--- a/src/Tokenizer.zig
+++ b/src/Tokenizer.zig
@@ -336,10 +336,18 @@ fn testExpected(source: []const u8, expected: []const Token.Id) !void {
         .buffer = source,
     };
 
+    var token_len: usize = 0;
     for (expected) |exp| {
+        token_len += 1;
         const token = tokenizer.next();
         try testing.expectEqual(exp, token.id);
     }
+
+    while (tokenizer.next().id != .Eof) {
+        token_len += 1; // consume all tokens
+    }
+
+    try testing.expectEqual(expected.len, token_len);
 }
 
 test "empty doc" {
@@ -440,7 +448,7 @@ test "inline mapped sequence of values" {
     });
 }
 
-test "part of tdb" {
+test "part of tbd" {
     try testExpected(
         \\--- !tapi-tbd
         \\tbd-version:     4
@@ -499,6 +507,28 @@ test "part of tdb" {
         .NewLine,
         .DocEnd,
         .Eof,
+    });
+}
+
+test "Unindented list" {
+    try testExpected(
+        \\b:
+        \\- foo: 1
+        \\c: 1
+    , &[_]Token.Id{
+        .Literal,
+        .MapValueInd,
+        .NewLine,
+        .SeqItemInd,
+        .Literal,
+        .MapValueInd,
+        .Space,
+        .Literal,
+        .NewLine,
+        .Literal,
+        .MapValueInd,
+        .Space,
+        .Literal,
     });
 }
 

--- a/src/Tokenizer.zig
+++ b/src/Tokenizer.zig
@@ -18,9 +18,6 @@ pub const Token = struct {
     id: Id,
     start: usize,
     end: usize,
-    // Count of spaces/tabs.
-    // Only active for .Space and .Tab tokens.
-    count: ?usize = null,
 
     pub const Id = enum {
         Eof,
@@ -95,8 +92,8 @@ pub fn next(self: *Tokenizer) Token {
     var state: union(enum) {
         Start,
         NewLine,
-        Space: usize,
-        Tab: usize,
+        Space,
+        Tab,
         Hyphen: usize,
         Dot: usize,
         SingleQuoteOrEscape,
@@ -109,10 +106,10 @@ pub fn next(self: *Tokenizer) Token {
         switch (state) {
             .Start => switch (c) {
                 ' ' => {
-                    state = .{ .Space = 1 };
+                    state = .Space;
                 },
                 '\t' => {
-                    state = .{ .Tab = 1 };
+                    state = .Tab;
                 },
                 '\n' => {
                     result.id = .NewLine;
@@ -213,23 +210,17 @@ pub fn next(self: *Tokenizer) Token {
                     state = .Literal;
                 },
             },
-            .Space => |*count| switch (c) {
-                ' ' => {
-                    count.* += 1;
-                },
+            .Space => switch (c) {
+                ' ' => {},
                 else => {
                     result.id = .Space;
-                    result.count = count.*;
                     break;
                 },
             },
-            .Tab => |*count| switch (c) {
-                ' ' => {
-                    count.* += 1;
-                },
+            .Tab => switch (c) {
+                '\t' => {},
                 else => {
                     result.id = .Tab;
-                    result.count = count.*;
                     break;
                 },
             },

--- a/src/main.zig
+++ b/src/main.zig
@@ -548,8 +548,6 @@ test "simple map untyped with a list of maps. no indent" {
     var yaml = try Yaml.load(testing.allocator, source);
     defer yaml.deinit();
 
-    std.debug.print("\n\n", .{});
-
     try testing.expectEqual(yaml.docs.items.len, 1);
 
     const map = yaml.docs.items[0].map;

--- a/src/main.zig
+++ b/src/main.zig
@@ -510,6 +510,83 @@ test "simple map untyped" {
     try testing.expectEqual(map.get("a").?.int, 0);
 }
 
+test "simple map untyped with a list of maps" {
+    const source =
+        \\a: 0
+        \\b: 
+        \\  - foo: 1
+        \\    bar: 2
+        \\  - foo: 3
+        \\    bar: 4
+        \\c: 1
+    ;
+
+    var yaml = try Yaml.load(testing.allocator, source);
+    defer yaml.deinit();
+
+    try testing.expectEqual(yaml.docs.items.len, 1);
+
+    const map = yaml.docs.items[0].map;
+    try testing.expect(map.contains("a"));
+    try testing.expect(map.contains("b"));
+    try testing.expect(map.contains("c"));
+    try testing.expectEqual(map.get("a").?.int, 0);
+    try testing.expectEqual(map.get("c").?.int, 1);
+    try testing.expectEqual(map.get("b").?.list[0].map.get("foo").?.int, 1);
+    try testing.expectEqual(map.get("b").?.list[0].map.get("bar").?.int, 2);
+    try testing.expectEqual(map.get("b").?.list[1].map.get("foo").?.int, 3);
+    try testing.expectEqual(map.get("b").?.list[1].map.get("bar").?.int, 4);
+}
+
+test "simple map untyped with a list of maps. no indent" {
+    const source =
+        \\b: 
+        \\- foo: 1
+        \\c: 1
+    ;
+
+    var yaml = try Yaml.load(testing.allocator, source);
+    defer yaml.deinit();
+
+    std.debug.print("\n\n", .{});
+
+    try testing.expectEqual(yaml.docs.items.len, 1);
+
+    const map = yaml.docs.items[0].map;
+    try testing.expect(map.contains("b"));
+    try testing.expect(map.contains("c"));
+    try testing.expectEqual(map.get("c").?.int, 1);
+    try testing.expectEqual(map.get("b").?.list[0].map.get("foo").?.int, 1);
+}
+
+test "simple map untyped with a list of maps. no indent 2" {
+    const source =
+        \\a: 0
+        \\b:
+        \\- foo: 1
+        \\  bar: 2
+        \\- foo: 3
+        \\  bar: 4
+        \\c: 1
+    ;
+
+    var yaml = try Yaml.load(testing.allocator, source);
+    defer yaml.deinit();
+
+    try testing.expectEqual(yaml.docs.items.len, 1);
+
+    const map = yaml.docs.items[0].map;
+    try testing.expect(map.contains("a"));
+    try testing.expect(map.contains("b"));
+    try testing.expect(map.contains("c"));
+    try testing.expectEqual(map.get("a").?.int, 0);
+    try testing.expectEqual(map.get("c").?.int, 1);
+    try testing.expectEqual(map.get("b").?.list[0].map.get("foo").?.int, 1);
+    try testing.expectEqual(map.get("b").?.list[0].map.get("bar").?.int, 2);
+    try testing.expectEqual(map.get("b").?.list[1].map.get("foo").?.int, 3);
+    try testing.expectEqual(map.get("b").?.list[1].map.get("bar").?.int, 4);
+}
+
 test "simple map typed" {
     const source =
         \\a: 0

--- a/src/parse.zig
+++ b/src/parse.zig
@@ -471,6 +471,10 @@ const Parser = struct {
                         if (self.eatToken(.MapValueInd)) |_| {
                             if (self.eatToken(.NewLine)) |_| {
                                 try self.openScope();
+                            } else {
+                                try self.scopes.append(self.allocator, .{
+                                    .indent = self.scopes.items[self.scopes.items.len - 1].indent + 2,
+                                });
                             }
                             // nested map
                             const map_node = try self.map(pos);

--- a/src/parse.zig
+++ b/src/parse.zig
@@ -202,10 +202,16 @@ pub const Node = struct {
     };
 };
 
+pub const LineCol = struct {
+    line: usize,
+    col: usize,
+};
+
 pub const Tree = struct {
     allocator: Allocator,
     source: []const u8,
     tokens: []Token,
+    line_cols: std.AutoHashMap(TokenIndex, LineCol),
     docs: std.ArrayListUnmanaged(*Node) = .{},
 
     pub fn init(allocator: Allocator) Tree {
@@ -213,11 +219,13 @@ pub const Tree = struct {
             .allocator = allocator,
             .source = undefined,
             .tokens = undefined,
+            .line_cols = std.AutoHashMap(TokenIndex, LineCol).init(allocator),
         };
     }
 
     pub fn deinit(self: *Tree) void {
         self.allocator.free(self.tokens);
+        self.line_cols.deinit();
         for (self.docs.items) |doc| {
             doc.deinit(self.allocator);
             self.allocator.destroy(doc);
@@ -228,12 +236,29 @@ pub const Tree = struct {
     pub fn parse(self: *Tree, source: []const u8) !void {
         var tokenizer = Tokenizer{ .buffer = source };
         var tokens = std.ArrayList(Token).init(self.allocator);
-        errdefer tokens.deinit();
+        defer tokens.deinit();
+
+        var line: usize = 0;
+        var prev_line_last_col: usize = 0;
 
         while (true) {
             const token = tokenizer.next();
+            const tok_id = tokens.items.len;
             try tokens.append(token);
-            if (token.id == .Eof) break;
+
+            try self.line_cols.putNoClobber(tok_id, .{
+                .line = line,
+                .col = token.start - prev_line_last_col,
+            });
+
+            switch (token.id) {
+                .Eof => break,
+                .NewLine => {
+                    line += 1;
+                    prev_line_last_col = token.end;
+                },
+                else => {},
+            }
         }
 
         self.source = source;
@@ -244,15 +269,12 @@ pub const Tree = struct {
             .allocator = self.allocator,
             .tree = self,
             .token_it = &it,
+            .line_cols = &self.line_cols,
         };
-        defer parser.deinit();
-
-        try parser.scopes.append(self.allocator, .{
-            .indent = 0,
-        });
 
         while (true) {
             if (parser.token_it.peek() == null) return;
+
             const pos = parser.token_it.pos;
             const token = parser.token_it.next();
 
@@ -274,22 +296,12 @@ const Parser = struct {
     allocator: Allocator,
     tree: *Tree,
     token_it: *TokenIterator,
-    scopes: std.ArrayListUnmanaged(Scope) = .{},
-
-    const Scope = struct {
-        indent: usize,
-    };
-
-    fn deinit(self: *Parser) void {
-        self.scopes.deinit(self.allocator);
-    }
+    line_cols: *const std.AutoHashMap(TokenIndex, LineCol),
 
     fn doc(self: *Parser, start: TokenIndex) ParseError!*Node.Doc {
         const node = try self.allocator.create(Node.Doc);
         errdefer self.allocator.destroy(node);
-        node.* = .{
-            .start = start,
-        };
+        node.* = .{ .start = start };
         node.base.tree = self.tree;
 
         self.token_it.seekTo(start);
@@ -351,19 +363,24 @@ const Parser = struct {
     fn map(self: *Parser, start: TokenIndex) ParseError!*Node.Map {
         const node = try self.allocator.create(Node.Map);
         errdefer self.allocator.destroy(node);
-        node.* = .{
-            .start = start,
-        };
+        node.* = .{ .start = start };
         node.base.tree = self.tree;
 
         self.token_it.seekTo(start);
 
         log.debug("Map start: {}, {}", .{ start, self.tree.tokens[start] });
-        log.debug("Current scope: {}", .{self.scopes.items[self.scopes.items.len - 1]});
+
+        const col = self.getCol(start);
 
         while (true) {
+            self.eatCommentsAndSpace();
+
             // Parse key.
             const key_pos = self.token_it.pos;
+            if (self.getCol(key_pos) != col) {
+                break;
+            }
+
             const key = self.token_it.next();
             switch (key.id) {
                 .Literal => {},
@@ -377,13 +394,13 @@ const Parser = struct {
 
             // Separator
             _ = try self.expectToken(.MapValueInd);
-            self.eatCommentsAndSpace();
 
             // Parse value.
             const value: *Node = value: {
                 if (self.eatToken(.NewLine)) |_| {
+                    self.eatCommentsAndSpace();
+
                     // Explicit, complex value such as list or map.
-                    try self.openScope();
                     const value_pos = self.token_it.pos;
                     const value = self.token_it.next();
                     switch (value.id) {
@@ -403,6 +420,8 @@ const Parser = struct {
                         },
                     }
                 } else {
+                    self.eatCommentsAndSpace();
+
                     const value_pos = self.token_it.pos;
                     const value = self.token_it.next();
                     switch (value.id) {
@@ -429,11 +448,7 @@ const Parser = struct {
                 .value = value,
             });
 
-            if (self.eatToken(.NewLine)) |_| {
-                if (try self.closeScope()) {
-                    break;
-                }
-            }
+            _ = self.eatToken(.NewLine);
         }
 
         node.end = self.token_it.pos - 1;
@@ -454,14 +469,18 @@ const Parser = struct {
         self.token_it.seekTo(start);
 
         log.debug("List start: {}, {}", .{ start, self.tree.tokens[start] });
-        log.debug("Current scope: {}", .{self.scopes.items[self.scopes.items.len - 1]});
+
+        const col = self.getCol(start);
 
         while (true) {
+            self.eatCommentsAndSpace();
+
+            if (self.getCol(self.token_it.pos) != col) {
+                break;
+            }
             _ = self.eatToken(.SeqItemInd) orelse {
-                _ = try self.closeScope();
                 break;
             };
-            self.eatCommentsAndSpace();
 
             const pos = self.token_it.pos;
             const token = self.token_it.next();
@@ -469,13 +488,6 @@ const Parser = struct {
                 switch (token.id) {
                     .Literal, .SingleQuote, .DoubleQuote => {
                         if (self.eatToken(.MapValueInd)) |_| {
-                            if (self.eatToken(.NewLine)) |_| {
-                                try self.openScope();
-                            } else {
-                                try self.scopes.append(self.allocator, .{
-                                    .indent = self.scopes.items[self.scopes.items.len - 1].indent + 2,
-                                });
-                            }
                             // nested map
                             const map_node = try self.map(pos);
                             break :value &map_node.base;
@@ -510,15 +522,12 @@ const Parser = struct {
     fn list_bracketed(self: *Parser, start: TokenIndex) ParseError!*Node.List {
         const node = try self.allocator.create(Node.List);
         errdefer self.allocator.destroy(node);
-        node.* = .{
-            .start = start,
-        };
+        node.* = .{ .start = start };
         node.base.tree = self.tree;
 
         self.token_it.seekTo(start);
 
         log.debug("List start: {}, {}", .{ start, self.tree.tokens[start] });
-        log.debug("Current scope: {}", .{self.scopes.items[self.scopes.items.len - 1]});
 
         _ = try self.expectToken(.FlowSeqStart);
 
@@ -570,7 +579,6 @@ const Parser = struct {
             .string_value = .{},
         };
         errdefer node.string_value.deinit(self.allocator);
-
         node.base.tree = self.tree;
 
         self.token_it.seekTo(start);
@@ -666,48 +674,6 @@ const Parser = struct {
         return node;
     }
 
-    fn openScope(self: *Parser) !void {
-        const peek = self.token_it.peek() orelse return error.UnexpectedEof;
-        if (peek.id != .Space and peek.id != .Tab) {
-            // No need to open scope.
-            return;
-        }
-        const indent = self.token_it.next().count.?;
-        const prev_scope = self.scopes.items[self.scopes.items.len - 1];
-        if (indent < prev_scope.indent) {
-            return error.MalformedYaml;
-        }
-
-        log.debug("Opening scope...", .{});
-
-        try self.scopes.append(self.allocator, .{
-            .indent = indent,
-        });
-    }
-
-    fn closeScope(self: *Parser) !bool {
-        const indent = indent: {
-            const peek = self.token_it.peek() orelse return error.UnexpectedEof;
-            switch (peek.id) {
-                .Space, .Tab => {
-                    break :indent self.token_it.next().count.?;
-                },
-                else => {
-                    break :indent 0;
-                },
-            }
-        };
-
-        const scope = self.scopes.items[self.scopes.items.len - 1];
-        if (indent < scope.indent) {
-            log.debug("Closing scope...", .{});
-            _ = self.scopes.pop();
-            return true;
-        }
-
-        return false;
-    }
-
     fn eatCommentsAndSpace(self: *Parser) void {
         while (true) {
             _ = self.token_it.peek() orelse return;
@@ -741,6 +707,14 @@ const Parser = struct {
 
     fn expectToken(self: *Parser, id: Token.Id) ParseError!TokenIndex {
         return self.eatToken(id) orelse error.UnexpectedToken;
+    }
+
+    fn getLine(self: *Parser, index: TokenIndex) usize {
+        return self.line_cols.get(index).?.line;
+    }
+
+    fn getCol(self: *Parser, index: TokenIndex) usize {
+        return self.line_cols.get(index).?.col;
     }
 };
 


### PR DESCRIPTION
Fixes #6 by creating a new scope when we start a map inside of a seq. I think this is the simplest way to fix this, but please let me know if I'm missing something.

I ran into this when the linker (zig ld) failed to parse my .tbd file. I reference my framework files with Nix, and my .tbd files are formatted a bit differently. For example the Foundation.tbd looks like this:

```yaml
# ...
uuids:
- target: x86_64-macos
  value: 44A7115B-7FF0-3300-B61B-0FA71B63C715
- target: x86_64-maccatalyst
  value: 44A7115B-7FF0-3300-B61B-0FA71B63C715
- target: arm64-macos
  value: 00000000-0000-0000-0000-000000000000
- target: arm64-maccatalyst
  value: 00000000-0000-0000-0000-000000000000
- target: arm64e-macos
  value: 5CEA7350-F274-39AE-9F27-D9813F2C3A76
- target: arm64e-maccatalyst
  value: 5CEA7350-F274-39AE-9F27-D9813F2C3A76
install-name:    '/System/Library/Frameworks/Foundation.framework/Versions/C/Foundation'
# ...
```

Once this change looks good I can make a similar change in https://github.com/ziglang/zig/blob/master/src/link/tapi/parse.zig so we can fix this issue in the linker.

Thanks!
