### PR TITLE
Refactor handling of single- and double-quoted strings

### DIFF
--- a/src/Tokenizer.zig
+++ b/src/Tokenizer.zig
@@ -334,18 +334,16 @@ fn testExpected(source: []const u8, expected: []const Token.Id) !void {
         .buffer = source,
     };
 
-    var token_len: usize = 0;
-    for (expected) |exp| {
-        token_len += 1;
+    var given = std.ArrayList(Token.Id).init(testing.allocator);
+    defer given.deinit();
+
+    while (true) {
         const token = tokenizer.next();
-        try testing.expectEqual(exp, token.id);
+        try given.append(token.id);
+        if (token.id == .eof) break;
     }
 
-    while (tokenizer.next().id != .eof) {
-        token_len += 1; // consume all tokens
-    }
-
-    try testing.expectEqual(expected.len, token_len);
+    try testing.expectEqualSlices(Token.Id, expected, given.items);
 }
 
 test {
@@ -531,6 +529,7 @@ test "Unindented list" {
         .map_value_ind,
         .space,
         .literal,
+        .eof,
     });
 }
 

--- a/src/Tokenizer.zig
+++ b/src/Tokenizer.zig
@@ -6,13 +6,6 @@ const testing = std.testing;
 
 buffer: []const u8,
 index: usize = 0,
-string_type: StringType = .unquoted,
-
-const StringType = enum {
-    unquoted,
-    single_quoted,
-    double_quoted,
-};
 
 pub const Token = struct {
     id: Id,
@@ -40,10 +33,9 @@ pub const Token = struct {
         alias,          // *
         anchor,         // &
         tag,            // !
-        single_quote,   // '
-        double_quote,   // "
-        escape_seq,     // '' for single quoted strings, starts with \ for double quoted strings
 
+        single_quoted,   // '...'
+        double_quoted,   // "..."
         literal,
         // zig fmt: on
     };
@@ -101,15 +93,15 @@ pub fn next(self: *Tokenizer) Token {
         .end = undefined,
     };
 
-    var state: union(enum) {
+    var state: enum {
         start,
         new_line,
         space,
         tab,
         comment,
-        single_quote_or_escape,
+        single_quoted,
+        double_quoted,
         literal,
-        escape_seq,
     } = .start;
 
     while (self.index < self.buffer.len) : (self.index += 1) {
@@ -174,34 +166,6 @@ pub fn next(self: *Tokenizer) Token {
                     self.index += 1;
                     break;
                 },
-                '\'' => switch (self.string_type) {
-                    .unquoted => {
-                        result.id = .single_quote;
-                        self.string_type = if (self.string_type == .single_quoted)
-                            .unquoted
-                        else
-                            .single_quoted;
-                        self.index += 1;
-                        break;
-                    },
-                    .single_quoted => {
-                        state = .single_quote_or_escape;
-                    },
-                    .double_quoted => {
-                        result.id = .single_quote;
-                        self.index += 1;
-                        break;
-                    },
-                },
-                '"' => {
-                    result.id = .double_quote;
-                    self.string_type = if (self.string_type == .double_quoted)
-                        .unquoted
-                    else
-                        .double_quoted;
-                    self.index += 1;
-                    break;
-                },
                 '[' => {
                     result.id = .flow_seq_start;
                     self.index += 1;
@@ -227,10 +191,11 @@ pub fn next(self: *Tokenizer) Token {
                     self.index += 1;
                     break;
                 },
-                '\\' => if (self.string_type == .double_quoted) {
-                    state = .escape_seq;
-                } else {
-                    state = .literal;
+                '\'' => {
+                    state = .single_quoted;
+                },
+                '"' => {
+                    state = .double_quoted;
                 },
                 else => {
                     state = .literal;
@@ -270,27 +235,27 @@ pub fn next(self: *Tokenizer) Token {
                 else => {}, // TODO this should be an error condition
             },
 
-            .single_quote_or_escape => switch (c) {
-                '\'' => {
-                    result.id = .escape_seq;
+            .single_quoted => switch (c) {
+                '\'' => if (!self.matchesPattern("''")) {
+                    result.id = .single_quoted;
+                    self.index += 1;
+                    break;
+                } else {
+                    self.index += "''".len - 1;
+                },
+                else => {},
+            },
+
+            .double_quoted => switch (c) {
+                '"' => {
+                    result.id = .double_quoted;
                     self.index += 1;
                     break;
                 },
-                else => {
-                    self.string_type = .unquoted;
-                    result.id = .single_quote;
-                    break;
-                },
+                else => {},
             },
 
             .literal => switch (c) {
-                '\\' => {
-                    result.id = .literal;
-                    if (self.string_type == .double_quoted) {
-                        // escape sequence
-                        break;
-                    }
-                },
                 '\r', '\n', ' ', '\'', '"', ',', ':', ']', '}' => {
                     result.id = .literal;
                     break;
@@ -299,13 +264,6 @@ pub fn next(self: *Tokenizer) Token {
                     result.id = .literal;
                 },
             },
-
-            .escape_seq => {
-                // Only support single character escape codes for now...
-                result.id = .escape_seq;
-                self.index += 1;
-                break;
-            },
         }
     }
 
@@ -313,9 +271,6 @@ pub fn next(self: *Tokenizer) Token {
         switch (state) {
             .literal => {
                 result.id = .literal;
-            },
-            .single_quote_or_escape => {
-                result.id = .single_quote;
             },
             else => {},
         }
@@ -501,9 +456,7 @@ test "part of tbd" {
         .literal,
         .map_value_ind,
         .space,
-        .single_quote,
-        .literal,
-        .single_quote,
+        .single_quoted,
         .new_line,
         .doc_end,
         .eof,
@@ -541,30 +494,12 @@ test "escape sequences" {
         .literal,
         .map_value_ind,
         .space,
-        .single_quote,
-        .literal,
-        .escape_seq,
-        .literal,
-        .space,
-        .literal,
-        .space,
-        .literal,
-        .single_quote,
+        .single_quoted,
         .new_line,
         .literal,
         .map_value_ind,
         .space,
-        .double_quote,
-        .literal,
-        .space,
-        .literal,
-        .escape_seq,
-        .literal,
-        .space,
-        .literal,
-        .escape_seq,
-        .literal,
-        .double_quote,
+        .double_quoted,
         .eof,
     });
 }
@@ -591,6 +526,21 @@ test "comments" {
         .new_line,
         .seq_item_ind,
         .literal,
+        .eof,
+    });
+}
+
+test "quoted literals" {
+    try testExpected(
+        \\'#000000'
+        \\'[000000'
+        \\"&someString"
+    , &[_]Token.Id{
+        .single_quoted,
+        .new_line,
+        .single_quoted,
+        .new_line,
+        .double_quoted,
         .eof,
     });
 }

--- a/src/parse/test.zig
+++ b/src/parse/test.zig
@@ -618,11 +618,11 @@ test "doc with two string is bad" {
     , error.UnexpectedToken);
 }
 
-test "single quote string cannot have new lines" {
-    try parseError(
+test "single quote string can have new lines" {
+    try parseSuccess(
         \\'what is this
         \\ thing?'
-    , error.UnexpectedToken);
+    );
 }
 
 test "single quote string on one line is fine" {
@@ -631,11 +631,11 @@ test "single quote string on one line is fine" {
     );
 }
 
-test "double quote string cannot have new lines" {
-    try parseError(
+test "double quote string can have new lines" {
+    try parseSuccess(
         \\"what is this
         \\ thing?"
-    , error.UnexpectedToken);
+    );
 }
 
 test "double quote string on one line is fine" {

--- a/src/yaml/test.zig
+++ b/src/yaml/test.zig
@@ -223,13 +223,15 @@ test "double quoted string" {
         \\- "hello"
         \\- "\"here\" are some escaped quotes"
         \\- "newlines and tabs\nare\tsupported"
+        \\- "let's have
+        \\some fun!"
     ;
 
     var yaml = try Yaml.load(testing.allocator, source);
     defer yaml.deinit();
 
-    const arr = try yaml.parse([3][]const u8);
-    try testing.expectEqual(arr.len, 3);
+    const arr = try yaml.parse([4][]const u8);
+    try testing.expectEqual(arr.len, 4);
     try testing.expectEqualStrings("hello", arr[0]);
     try testing.expectEqualStrings(
         \\"here" are some escaped quotes
@@ -238,6 +240,10 @@ test "double quoted string" {
         \\newlines and tabs
         \\are	supported
     , arr[2]);
+    try testing.expectEqualStrings(
+        \\let's have
+        \\some fun!
+    , arr[3]);
 }
 
 test "multidoc typed as a slice of structs" {


### PR DESCRIPTION
Fixes #11 

**tl;dr** I figured the current approach for generically handling single- and double-quoted strings was not easily extensible, and instead of cramming tokenizing quoted phrases in the tokenizer, why not just defer parsing the contents of the quoted strings until the parser run? It seems like the approach implemented in this PR is simpler and cleaner and more easily extensible. It works like this:

1. tokenizer encodes the entire quoted string as a single token, either `.single_quoted` or `.double_quoted`, tracking any encountered escape sequence
2. parser parses the contents of the quoted string substituting requested characters, codepoints, etc. in place of the encountered escape sequences

cc @rudedogg |'ve re-used your test case from #11 (thank you!), and have added you as a co-author to the matching commit as a way of attributing that bit of code to you - hope that's OK!