### PR TITLE
Build: Fixes build and run tests with latest Zig master

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 .gyro
 .zigmod
 deps.zig
+zig-cache
+zig-out

--- a/src/parse.zig
+++ b/src/parse.zig
@@ -288,7 +288,7 @@ pub const Tree = struct {
         }
 
         self.source = source;
-        self.tokens = tokens.toOwnedSlice();
+        self.tokens = try tokens.toOwnedSlice();
 
         var it = TokenIterator{ .buffer = self.tokens };
         var parser = Parser{

--- a/src/yaml.zig
+++ b/src/yaml.zig
@@ -74,7 +74,7 @@ pub const Value = union(enum) {
 
                 const first = list[0];
                 if (first.isCompound()) {
-                    for (list) |elem, i| {
+                    for (list, 0..) |elem, i| {
                         try writer.writeByteNTimes(' ', args.indentation);
                         try writer.writeAll("- ");
                         try elem.stringify(writer, .{
@@ -89,7 +89,7 @@ pub const Value = union(enum) {
                 }
 
                 try writer.writeAll("[ ");
-                for (list) |elem, i| {
+                for (list, 0..) |elem, i| {
                     try elem.stringify(writer, args);
                     if (i < len - 1) {
                         try writer.writeAll(", ");
@@ -180,7 +180,7 @@ pub const Value = union(enum) {
                 out_list.appendAssumeCapacity(value);
             }
 
-            return Value{ .list = out_list.toOwnedSlice() };
+            return Value{ .list = try out_list.toOwnedSlice() };
         } else if (node.cast(Node.Value)) |value| {
             const raw = tree.getRaw(node.start, node.end);
 
@@ -221,7 +221,7 @@ pub const Value = union(enum) {
                     }
                 }
 
-                return Value{ .list = list.toOwnedSlice() };
+                return Value{ .list = try list.toOwnedSlice() };
             } else {
                 var map = Map.init(arena);
                 errdefer map.deinit();
@@ -275,7 +275,7 @@ pub const Value = union(enum) {
                         }
                     }
 
-                    return Value{ .list = list.toOwnedSlice() };
+                    return Value{ .list = try list.toOwnedSlice() };
                 },
                 else => {
                     @compileError("Unhandled type: {s}" ++ @typeName(@TypeOf(input)));
@@ -350,7 +350,7 @@ pub const Yaml = struct {
         switch (@typeInfo(T)) {
             .Array => |info| {
                 var parsed: T = undefined;
-                for (self.docs.items) |doc, i| {
+                for (self.docs.items, 0..) |doc, i| {
                     parsed[i] = try self.parseValue(info.child, doc);
                 }
                 return parsed;
@@ -359,7 +359,7 @@ pub const Yaml = struct {
                 switch (info.size) {
                     .Slice => {
                         var parsed = try self.arena.allocator().alloc(info.child, self.docs.items.len);
-                        for (self.docs.items) |doc, i| {
+                        for (self.docs.items, 0..) |doc, i| {
                             parsed[i] = try self.parseValue(info.child, doc);
                         }
                         return parsed;
@@ -399,7 +399,7 @@ pub const Yaml = struct {
 
         if (union_info.tag_type) |_| {
             inline for (union_info.fields) |field| {
-                if (self.parseValue(field.field_type, value)) |u_value| {
+                if (self.parseValue(field.type, value)) |u_value| {
                     return @unionInit(T, field.name, u_value);
                 } else |err| {
                     if (@as(@TypeOf(err) || error{TypeMismatch}, err) != error.TypeMismatch) return err;
@@ -426,16 +426,16 @@ pub const Yaml = struct {
                 break :blk map.get(field_name);
             };
 
-            if (@typeInfo(field.field_type) == .Optional) {
-                @field(parsed, field.name) = try self.parseOptional(field.field_type, value);
+            if (@typeInfo(field.type) == .Optional) {
+                @field(parsed, field.name) = try self.parseOptional(field.type, value);
                 continue;
             }
 
             const unwrapped = value orelse {
-                log.err("missing struct field: {s}: {s}", .{ field.name, @typeName(field.field_type) });
+                log.err("missing struct field: {s}: {s}", .{ field.name, @typeName(field.type) });
                 return error.StructFieldMissing;
             };
-            @field(parsed, field.name) = try self.parseValue(field.field_type, unwrapped);
+            @field(parsed, field.name) = try self.parseValue(field.type, unwrapped);
         }
 
         return parsed;
@@ -452,7 +452,7 @@ pub const Yaml = struct {
                 }
 
                 var parsed = try arena.alloc(ptr_info.child, value.list.len);
-                for (value.list) |elem, i| {
+                for (value.list, 0..) |elem, i| {
                     parsed[i] = try self.parseValue(ptr_info.child, elem);
                 }
                 return parsed;
@@ -466,7 +466,7 @@ pub const Yaml = struct {
         if (array_info.len != list.len) return error.ArraySizeMismatch;
 
         var parsed: T = undefined;
-        for (list) |elem, i| {
+        for (list, 0..) |elem, i| {
             parsed[i] = try self.parseValue(array_info.child, elem);
         }
 
@@ -474,7 +474,7 @@ pub const Yaml = struct {
     }
 
     pub fn stringify(self: Yaml, writer: anytype) !void {
-        for (self.docs.items) |doc, i| {
+        for (self.docs.items, 0..) |doc, i| {
             try writer.writeAll("---");
             if (self.tree.?.getDirective(i)) |directive| {
                 try writer.print(" !{s}", .{directive});

--- a/test/test.zig
+++ b/test/test.zig
@@ -32,15 +32,15 @@ test "simple" {
             if (self.numbers.len != other.numbers.len) return false;
             if (self.finally.len != other.finally.len) return false;
 
-            for (self.names) |lhs, i| {
+            for (self.names, 0..) |lhs, i| {
                 if (!mem.eql(u8, lhs, other.names[i])) return false;
             }
 
-            for (self.numbers) |lhs, i| {
+            for (self.numbers, 0..) |lhs, i| {
                 if (lhs != other.numbers[i]) return false;
             }
 
-            for (self.finally) |lhs, i| {
+            for (self.finally, 0..) |lhs, i| {
                 if (lhs != other.finally[i]) return false;
             }
 
@@ -96,7 +96,7 @@ const LibTbd = struct {
         if (self.tbd_version != other.tbd_version) return false;
         if (self.targets.len != other.targets.len) return false;
 
-        for (self.targets) |target, i| {
+        for (self.targets, 0..) |target, i| {
             if (!mem.eql(u8, target, other.targets[i])) return false;
         }
 
@@ -118,17 +118,17 @@ const LibTbd = struct {
 
             if (reexported_libraries.len != o_reexported_libraries.len) return false;
 
-            for (reexported_libraries) |reexport, i| {
+            for (reexported_libraries, 0..) |reexport, i| {
                 const o_reexport = o_reexported_libraries[i];
                 if (reexport.targets.len != o_reexport.targets.len) return false;
                 if (reexport.libraries.len != o_reexport.libraries.len) return false;
 
-                for (reexport.targets) |target, j| {
+                for (reexport.targets, 0..) |target, j| {
                     const o_target = o_reexport.targets[j];
                     if (!mem.eql(u8, target, o_target)) return false;
                 }
 
-                for (reexport.libraries) |library, j| {
+                for (reexport.libraries, 0..) |library, j| {
                     const o_library = o_reexport.libraries[j];
                     if (!mem.eql(u8, library, o_library)) return false;
                 }
@@ -140,11 +140,11 @@ const LibTbd = struct {
 
             if (parent_umbrella.len != o_parent_umbrella.len) return false;
 
-            for (parent_umbrella) |pumbrella, i| {
+            for (parent_umbrella, 0..) |pumbrella, i| {
                 const o_pumbrella = o_parent_umbrella[i];
                 if (pumbrella.targets.len != o_pumbrella.targets.len) return false;
 
-                for (pumbrella.targets) |target, j| {
+                for (pumbrella.targets, 0..) |target, j| {
                     const o_target = o_pumbrella.targets[j];
                     if (!mem.eql(u8, target, o_target)) return false;
                 }
@@ -155,17 +155,17 @@ const LibTbd = struct {
 
         if (self.exports.len != other.exports.len) return false;
 
-        for (self.exports) |exp, i| {
+        for (self.exports, 0..) |exp, i| {
             const o_exp = other.exports[i];
             if (exp.targets.len != o_exp.targets.len) return false;
             if (exp.symbols.len != o_exp.symbols.len) return false;
 
-            for (exp.targets) |target, j| {
+            for (exp.targets, 0..) |target, j| {
                 const o_target = o_exp.targets[j];
                 if (!mem.eql(u8, target, o_target)) return false;
             }
 
-            for (exp.symbols) |symbol, j| {
+            for (exp.symbols, 0..) |symbol, j| {
                 const o_symbol = o_exp.symbols[j];
                 if (!mem.eql(u8, symbol, o_symbol)) return false;
             }
@@ -304,7 +304,7 @@ test "multi lib tbd" {
         },
     };
 
-    for (result) |lib, i| {
+    for (result, 0..) |lib, i| {
         try testing.expect(lib.eql(expected[i]));
     }
 }


### PR DESCRIPTION
This PR fixes unit tests running against latest zig version.

More specifically:
* Fixes build steps.
* Run `zig fmt`.
* Use `Field` `type` instead of `type_field`
* `try list.toOwnedSlice()` instead of `list.toOwnedSlice()`

```
❯ zig version
0.11.0-dev.6558+98508a12c
```

```
❯ zig build test
All 79 tests passed.
All 3 tests passed.
```

