### PR TITLE
allow literals containig a colon not followed by space or newline

### DIFF
--- a/src/Tokenizer.zig
+++ b/src/Tokenizer.zig
@@ -135,6 +135,11 @@ pub fn next(self: *Tokenizer) Token {
                     result.id = .seq_item_ind;
                     self.index += "- ".len;
                     break;
+                } else if (self.matchesPattern("-\n")) {
+                    result.id = .seq_item_ind;
+                    // we do not skip the newline
+                    self.index += "-".len;
+                    break;
                 } else {
                     state = .literal;
                 },

--- a/src/Tokenizer.zig
+++ b/src/Tokenizer.zig
@@ -264,9 +264,15 @@ pub fn next(self: *Tokenizer) Token {
             },
 
             .literal => switch (c) {
-                '\r', '\n', ' ', '\'', '"', ',', ':', ']', '}' => {
+                '\r', '\n', ' ', '\'', '"', ',', ']', '}' => {
                     result.id = .literal;
                     break;
+                },
+                ':' => {
+                    result.id = .literal;
+                    if (self.matchesPattern(": ") or self.matchesPattern(":\n")) {
+                        break;
+                    }
                 },
                 else => {
                     result.id = .literal;
@@ -570,6 +576,18 @@ test "quoted literals" {
         .single_quoted,
         .new_line,
         .double_quoted,
+        .eof,
+    });
+}
+
+test "literal with colon" {
+    try testExpected(
+        \\string: a:bc
+    , &[_]Token.Id{
+        .literal,
+        .map_value_ind,
+        .space,
+        .literal,
         .eof,
     });
 }

--- a/src/parse/test.zig
+++ b/src/parse/test.zig
@@ -324,17 +324,40 @@ test "map of list of maps" {
     }
 }
 
-test "list of lists" {
+test "list of bracketed lists" {
     const source =
         \\- [name        , hr, avg  ]
         \\- [Mark McGwire , 65, 0.278]
         \\- [Sammy Sosa   , 63, 0.288]
     ;
-
     var tree = Tree.init(testing.allocator);
     defer tree.deinit();
     try tree.parse(source);
+    try testLoL(&tree);
+}
 
+test "list of hyphened lists" {
+    const source =
+        \\-
+        \\  - name
+        \\  - hr
+        \\  - avg
+        \\-
+        \\  - Mark McGwire
+        \\  - 65
+        \\  - 0.278
+        \\-
+        \\  - Sammy Sosa
+        \\  - 63
+        \\  - 0.288
+    ;
+    var tree = Tree.init(testing.allocator);
+    defer tree.deinit();
+    try tree.parse(source);
+    try testLoL(&tree);
+}
+
+fn testLoL(tree: *Tree) !void {
     try testing.expectEqual(tree.docs.items.len, 1);
 
     const doc = tree.docs.items[0].cast(Node.Doc).?;
@@ -701,10 +724,10 @@ test "simple list" {
 }
 
 test "list indentation matters" {
-    try parseSuccess(
+    try parseError(
         \\  - a
         \\- b
-    );
+    , error.UnexpectedToken);
 
     try parseSuccess(
         \\- a


### PR DESCRIPTION
This is a proposed fix for bug #18. It is implemented by allowing literals to contain a colon if it is not directly followed by an space or newline.  