### PR TITLE
Fix build with zig master 2023-11-21

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -9,7 +9,7 @@ pub fn build(b: *std.Build) void {
         .source_file = std.build.FileSource{ .path = "src/yaml.zig" },
     });
 
-    var yaml_tests = b.addTest(.{
+    const yaml_tests = b.addTest(.{
         .root_source_file = .{ .path = "src/yaml.zig" },
         .target = target,
         .optimize = optimize,

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -1,4 +1,11 @@
 .{
     .name = "zig-yaml",
     .version = "0.0.1",
+    .paths = .{
+        "src",
+        "build.zig",
+        "build.zig.zon",
+        "LICENSE",
+        "README.md",
+    },
 }

--- a/src/yaml.zig
+++ b/src/yaml.zig
@@ -487,7 +487,7 @@ pub fn stringify(allocator: Allocator, input: anytype, writer: anytype) !void {
     var arena = ArenaAllocator.init(allocator);
     defer arena.deinit();
 
-    var maybe_value = try Value.encode(arena.allocator(), input);
+    const maybe_value = try Value.encode(arena.allocator(), input);
 
     if (maybe_value) |value| {
         // TODO should we output as an explicit doc?


### PR DESCRIPTION
  - Add the paths field to build.zig.zon
  - Use const instead of var when there is no mutation

Probably the `paths` field should also include `gyro.zzz` and `zigmod.yml`