### PR TITLE
Fix issue when parsing second union field

### DIFF
--- a/src/yaml.zig
+++ b/src/yaml.zig
@@ -397,8 +397,10 @@ pub const Yaml = struct {
             inline for (union_info.fields) |field| {
                 if (self.parseValue(field.type, value)) |u_value| {
                     return @unionInit(T, field.name, u_value);
-                } else |err| {
-                    if (@as(@TypeOf(err) || error{TypeMismatch}, err) != error.TypeMismatch) return err;
+                } else |err| switch (err) {
+                    error.TypeMismatch => {},
+                    error.StructFieldMissing => {},
+                    else => return err,
                 }
             }
         } else return error.UntaggedUnion;

--- a/src/yaml/test.zig
+++ b/src/yaml/test.zig
@@ -202,6 +202,54 @@ test "typed nested structs" {
     try testing.expectEqualStrings("wait, what?", simple.a.c);
 }
 
+test "typed union with nested struct" {
+    const source =
+        \\a:
+        \\  b: hello there
+    ;
+
+    var yaml = try Yaml.load(testing.allocator, source);
+    defer yaml.deinit();
+
+    const simple = try yaml.parse(union(enum) {
+        tag_a: struct {
+            a: struct {
+                b: []const u8,
+            },
+        },
+        tag_c: struct {
+            c: struct {
+                d: []const u8,
+            },
+        },
+    });
+    try testing.expectEqualStrings("hello there", simple.tag_a.a.b);
+}
+
+test "typed union with nested struct 2" {
+    const source =
+        \\c:
+        \\  d: hello there
+    ;
+
+    var yaml = try Yaml.load(testing.allocator, source);
+    defer yaml.deinit();
+
+    const simple = try yaml.parse(union(enum) {
+        tag_a: struct {
+            a: struct {
+                b: []const u8,
+            },
+        },
+        tag_c: struct {
+            c: struct {
+                d: []const u8,
+            },
+        },
+    });
+    try testing.expectEqualStrings("hello there", simple.tag_c.c.d);
+}
+
 test "single quoted string" {
     const source =
         \\- 'hello'


### PR DESCRIPTION
When parsing the second field of a union and the first field is a struct, in the inlined loop, the first field returns error.StructFieldMissing which should be ignored, as error.TypeMismatch already is.