### PR TITLE
Infer base for int

### DIFF
--- a/src/yaml.zig
+++ b/src/yaml.zig
@@ -181,8 +181,7 @@ pub const Value = union(enum) {
             const raw = tree.getRaw(node.start, node.end);
 
             try_int: {
-                // TODO infer base for int
-                const int = std.fmt.parseInt(i64, raw, 10) catch break :try_int;
+                const int = std.fmt.parseInt(i64, raw, 0) catch break :try_int;
                 return Value{ .int = int };
             }
 

--- a/src/yaml/test.zig
+++ b/src/yaml/test.zig
@@ -76,6 +76,25 @@ test "list of mixed sign integer" {
     try testing.expectEqualSlices(i8, &[_]i8{ 0, -1, 2 }, &arr);
 }
 
+test "several integer bases" {
+    const source =
+        \\- 10
+        \\- -10
+        \\- 0x10
+        \\- -0X10
+        \\- 0o10
+        \\- -0O10
+    ;
+
+    var yaml = try Yaml.load(testing.allocator, source);
+    defer yaml.deinit();
+
+    try testing.expectEqual(yaml.docs.items.len, 1);
+
+    const arr = try yaml.parse([6]i8);
+    try testing.expectEqualSlices(i8, &[_]i8{ 10, -10, 16, -16, 8, -8 }, &arr);
+}
+
 test "simple map untyped" {
     const source =
         \\a: 0


### PR DESCRIPTION
Hexadecimals were being parsed as float.

Let `parseInt()` to infer the integer base by passing 0 as the third argument.