### PR TITLE
Update @fieldParentPtr behaviour to resolve change in nightly build 

### DIFF
--- a/src/parse.zig
+++ b/src/parse.zig
@@ -35,28 +35,28 @@ pub const Node = struct {
         if (self.tag != T.base_tag) {
             return null;
         }
-        return @fieldParentPtr(T, "base", self);
+        return @fieldParentPtr("base", self);
     }
 
     pub fn deinit(self: *Node, allocator: Allocator) void {
         switch (self.tag) {
             .doc => {
-                const parent = @fieldParentPtr(Node.Doc, "base", self);
+                const parent: *Node.Doc = @fieldParentPtr("base", self);
                 parent.deinit(allocator);
                 allocator.destroy(parent);
             },
             .map => {
-                const parent = @fieldParentPtr(Node.Map, "base", self);
+                const parent: *Node.Map = @fieldParentPtr("base", self);
                 parent.deinit(allocator);
                 allocator.destroy(parent);
             },
             .list => {
-                const parent = @fieldParentPtr(Node.List, "base", self);
+                const parent: *Node.List = @fieldParentPtr("base", self);
                 parent.deinit(allocator);
                 allocator.destroy(parent);
             },
             .value => {
-                const parent = @fieldParentPtr(Node.Value, "base", self);
+                const parent: *Node.Value = @fieldParentPtr("base", self);
                 parent.deinit(allocator);
                 allocator.destroy(parent);
             },
@@ -70,10 +70,10 @@ pub const Node = struct {
         writer: anytype,
     ) !void {
         return switch (self.tag) {
-            .doc => @fieldParentPtr(Node.Doc, "base", self).format(fmt, options, writer),
-            .map => @fieldParentPtr(Node.Map, "base", self).format(fmt, options, writer),
-            .list => @fieldParentPtr(Node.List, "base", self).format(fmt, options, writer),
-            .value => @fieldParentPtr(Node.Value, "base", self).format(fmt, options, writer),
+            .doc => @as(*const Node.Doc, @fieldParentPtr("base", self)).format(fmt, options, writer),
+            .map => @as(*const Node.Map, @fieldParentPtr("base", self)).format(fmt, options, writer),
+            .list => @as(*const Node.List, @fieldParentPtr("base", self)).format(fmt, options, writer),
+            .value => @as(*const Node.Value, @fieldParentPtr("base", self)).format(fmt, options, writer),
         };
     }
 


### PR DESCRIPTION
Updates the use of @fieldParentPtr to account for change documented here https://github.com/ziglang/zig/wiki/Using-Cast-Result-Type-Inference

Fixes issue #37 