### PR TITLE
Add Support For Yaml Bool

### DIFF
--- a/src/yaml.zig
+++ b/src/yaml.zig
@@ -199,16 +199,18 @@ pub const Value = union(enum) {
                 return Value{ .float = float };
             }
 
-            const lower_raw = try std.ascii.allocLowerString(arena, raw);
-            for (supportedTruthyBooleanValue) |v| {
-                if (std.mem.eql(u8, v, lower_raw)) {
-                    return Value{ .boolean = true };
+            if (raw.len <= 5 and raw.len > 0) {
+                const lower_raw = try std.ascii.allocLowerString(arena, raw);
+                for (supportedTruthyBooleanValue) |v| {
+                    if (std.mem.eql(u8, v, lower_raw)) {
+                        return Value{ .boolean = true };
+                    }
                 }
-            }
 
-            for (supportedFalsyBooleanValue) |v| {
-                if (std.mem.eql(u8, v, lower_raw)) {
-                    return Value{ .boolean = false };
+                for (supportedFalsyBooleanValue) |v| {
+                    if (std.mem.eql(u8, v, lower_raw)) {
+                        return Value{ .boolean = false };
+                    }
                 }
             }
 

--- a/src/yaml.zig
+++ b/src/yaml.zig
@@ -13,8 +13,8 @@ pub const parse = @import("parse.zig");
 const Node = parse.Node;
 const Tree = parse.Tree;
 const ParseError = parse.ParseError;
-const supportedTruthyBooleanValue: [11][]const u8 = .{ "y", "Y", "yes", "Yes", "YES", "on", "On", "ON", "true", "True", "TRUE" };
-const supportedFalsyBooleanValue: [11][]const u8 = .{ "n", "N", "no", "No", "NO", "off", "Off", "OFF", "false", "False", "FALSE" };
+const supportedTruthyBooleanValue: [4][]const u8 = .{ "y", "yes", "on", "true" };
+const supportedFalsyBooleanValue: [4][]const u8 = .{ "n", "no", "off", "false" };
 
 pub const YamlError = error{
     UnexpectedNodeType,
@@ -199,14 +199,15 @@ pub const Value = union(enum) {
                 return Value{ .float = float };
             }
 
+            const lower_raw = try std.ascii.allocLowerString(arena, raw);
             for (supportedTruthyBooleanValue) |v| {
-                if (std.mem.eql(u8, v, raw)) {
+                if (std.mem.eql(u8, v, lower_raw)) {
                     return Value{ .boolean = true };
                 }
             }
 
             for (supportedFalsyBooleanValue) |v| {
-                if (std.mem.eql(u8, v, raw)) {
+                if (std.mem.eql(u8, v, lower_raw)) {
                     return Value{ .boolean = false };
                 }
             }

--- a/test/simple.yaml
+++ b/test/simple.yaml
@@ -4,10 +4,11 @@ numbers:
   - -8
   - 6
 isyaml: false
+hasBoolean: NO
 nested:
   some: one
   wick: john doe
-  ok: false
+  ok: TRUE
 finally: [ 8.17,
            19.78      , 17 ,
            21 ]

--- a/test/simple.yaml
+++ b/test/simple.yaml
@@ -3,9 +3,11 @@ numbers:
   - 10
   - -8
   - 6
+isyaml: false
 nested:
   some: one
   wick: john doe
+  ok: false
 finally: [ 8.17,
            19.78      , 17 ,
            21 ]

--- a/test/test.zig
+++ b/test/test.zig
@@ -24,8 +24,10 @@ test "simple" {
         nested: struct {
             some: []const u8,
             wick: []const u8,
+            ok: bool,
         },
         finally: [4]f16,
+        isyaml: bool,
 
         pub fn eql(self: @This(), other: @This()) bool {
             if (self.names.len != other.names.len) return false;
@@ -61,7 +63,9 @@ test "simple" {
         .nested = .{
             .some = "one",
             .wick = "john doe",
+            .ok = false,
         },
+        .isyaml = false,
         .finally = [_]f16{ 8.17, 19.78, 17, 21 },
     };
     try testing.expect(result.eql(expected));

--- a/test/test.zig
+++ b/test/test.zig
@@ -28,6 +28,7 @@ test "simple" {
         },
         finally: [4]f16,
         isyaml: bool,
+        hasBoolean: bool,
 
         pub fn eql(self: @This(), other: @This()) bool {
             if (self.names.len != other.names.len) return false;
@@ -63,9 +64,10 @@ test "simple" {
         .nested = .{
             .some = "one",
             .wick = "john doe",
-            .ok = false,
+            .ok = true,
         },
         .isyaml = false,
+        .hasBoolean = false,
         .finally = [_]f16{ 8.17, 19.78, 17, 21 },
     };
     try testing.expect(result.eql(expected));


### PR DESCRIPTION
This PR suggest a fix for yaml boolean value particularly true and false value. This was as a result of a boolean usecase 

```.zig
const Simple = struct {
        names: []const []const u8,
        numbers: []const i16,
        nested: struct {
            some: []const u8,
            wick: []const u8,
            ok: bool,
        },
        finally: [4]f16,
        isyaml: bool,
};
```

Error Detail:
```
error: Unimplemented
/Users/soundboax/.cache/zig/p/1220841471bd4891cbb199d27cc5e7e0fb0a5b7c5388a70bd24fa3eb7285755c396c/src/yaml.zig:371:9: 0x100f300f7 in parseValue__anon_11054 (zebra)
        return switch (@typeInfo(T)) {
        ^
/Users/soundboax/.cache/zig/p/1220841471bd4891cbb199d27cc5e7e0fb0a5b7c5388a70bd24fa3eb7285755c396c/src/yaml.zig:413:23: 0x100f25b3b in parseOptional__anon_10792 (zebra)
        return @as(T, try self.parseValue(opt_info.child, unwrapped));
                      ^
/Users/soundboax/.cache/zig/p/1220841471bd4891cbb199d27cc5e7e0fb0a5b7c5388a70bd24fa3eb7285755c396c/src/yaml.zig:427:46: 0x100f1331f in parseStruct__anon_10720 (zebra)
                @field(parsed, field.name) = try self.parseOptional(field.type, value);
 
```

Proposition:

Since the parse value to a yaml field can also be true or false, this case should be handled. This PR proposes a possiblity for that.