### PR TITLE
Allow commas in unquoted string + empty map

### DIFF
--- a/src/parse.zig
+++ b/src/parse.zig
@@ -462,7 +462,11 @@ const Parser = struct {
                     self.token_it.seekBy(-1);
                     break;
                 },
+                .flow_map_end => {
+                    break;
+                },
                 else => {
+                    log.err("Unhandled token in map: {}", .{key});
                     // TODO key not being a literal
                     return error.Unhandled;
                 },

--- a/src/parse/test.zig
+++ b/src/parse/test.zig
@@ -750,6 +750,14 @@ test "empty list" {
     );
 }
 
+test "empty map" {
+    try parseSuccess(
+        \\a:
+        \\  b: {}
+        \\  c: { }
+    );
+}
+
 test "comment within a bracketed list is an error" {
     try parseError(
         \\[ # something

--- a/src/parse/test.zig
+++ b/src/parse/test.zig
@@ -65,7 +65,7 @@ test "explicit doc" {
 
 test "leaf in quotes" {
     const source =
-        \\key1: no quotes
+        \\key1: no quotes, comma
         \\key2: 'single quoted'
         \\key3: "double quoted"
     ;
@@ -101,7 +101,7 @@ test "leaf in quotes" {
         const end = tree.tokens[value.base.end];
         try testing.expectEqual(start.id, .literal);
         try testing.expectEqual(end.id, .literal);
-        try testing.expectEqualStrings("no quotes", tree.source[start.start..end.end]);
+        try testing.expectEqualStrings("no quotes, comma", tree.source[start.start..end.end]);
     }
 }
 


### PR DESCRIPTION
Hi Jakub,
thanks for the lib.

I found two minor issues with the libraries:

- `,` is a valid character for unquoted string, except in flow

From: https://yaml.org/spec/1.2.2/#733-plain-style
**inside** flow collections, plain scalars must not contain the “[”, “]”, “{”, “}” and “,” characters.
To handle this the tokenizer need to tracks if it's within a flow or not.

- `{}` is a valid map.

I can split the PR in two if you prefer, but also the two commits are easy to review independently.