### PR TITLE
fix: #23 #28 #35 list with map of lists issue

### DIFF
--- a/src/Tokenizer.zig
+++ b/src/Tokenizer.zig
@@ -136,6 +136,11 @@ pub fn next(self: *Tokenizer) Token {
                     result.id = .seq_item_ind;
                     self.index += "- ".len;
                     break;
+                } else if (self.matchesPattern("-\n")) {
+                    result.id = .seq_item_ind;
+                    // we do not skip the newline
+                    self.index += "-".len;
+                    break;
                 } else {
                     state = .literal;
                 },


### PR DESCRIPTION
👋 I ran into the same issue as in #23 #28 and #35 today. it looks like #28 hasn't been updated so took the tweaks that they had made and put them here. I made a bit more elaborate of a test based on the exact issue I encountered. with the changes in my local vendored copy things are working as expected!

I also changed the test [here](https://github.com/kubkon/zig-yaml/blob/main/src/parse/test.zig#L704-L707) to expect failure as I dont think that is valid?

```yaml
  - a
- b
``` 

at least the above complains in yaml validators and such and with the tweaks in this pr it raises the expected UnexpectedToken error.

~~unrelated, but I also think that with the recent changes the test package may need to get included in build.zig.zon since the build file imports from there -- works fine for local/vendored but not when including in my build.zig.zon as dep. happy to make another quick patch for this or can include here if wanted.~~ looks like sorted by #51 :)

im super new to zig so hopefully this is all cool. thanks for making this package! 🥳 

edit to include before/after output:

before:
```yaml
modes:
    - name: a
      fooers:
          - name: b
            do_thing:
                thing: blah
          - name: b
            fooers:
                - name: a
                  do_thing:
                      input: blah
                - name: c
                  do_thing:
                      input: blah
                - name: d
                  do_thing:
                      input: blah
                - name: c
                  fooers:
                      - name: b
                        do_thing:
                            input: blah
                      - name: d
                        fooers:
                            - name: b
                              do_thing:
                                  input: blah
```

and after:

```yaml
modes:
    - name: a
      accessible_modes:
          - name: b
            do_thing:
                thing: blah
    - name: b
      accessible_modes:
          - name: a
            do_thing:
                thing: blah
          - name: c
            do_thing:
                thing: blah
          - name: d
            do_thing:
                thing: blah
    - name: c
      accessible_modes:
          - name: b
            do_thing:
                thing: blah
    - name: d
      accessible_modes:
          - name: b
            do_thing:
                thing: blah
```