### PR TITLE
Fix zig build error and (maybe) issue #30 

### DIFF
--- a/src/yaml.zig
+++ b/src/yaml.zig
@@ -223,13 +223,13 @@ pub const Value = union(enum) {
 
     fn encode(arena: Allocator, input: anytype) YamlError!?Value {
         switch (@typeInfo(@TypeOf(input))) {
-            .comptime_int,
-            .int,
+            .ComptimeInt,
+            .Int,
             => return Value{ .int = math.cast(i64, input) orelse return error.Overflow },
 
-            .float => return Value{ .float = math.lossyCast(f64, input) },
+            .Float => return Value{ .float = math.lossyCast(f64, input) },
 
-            .@"struct" => |info| if (info.is_tuple) {
+            .Struct => |info| if (info.is_tuple) {
                 var list = std.ArrayList(Value).init(arena);
                 errdefer list.deinit();
                 try list.ensureTotalCapacityPrecise(info.fields.len);
@@ -256,7 +256,7 @@ pub const Value = union(enum) {
                 return Value{ .map = map };
             },
 
-            .@"union" => |info| if (info.tag_type) |tag_type| {
+            .Union => |info| if (info.tag_type) |tag_type| {
                 inline for (info.fields) |field| {
                     if (@field(tag_type, field.name) == input) {
                         return try encode(arena, @field(input, field.name));
@@ -264,11 +264,11 @@ pub const Value = union(enum) {
                 } else unreachable;
             } else return error.UntaggedUnion,
 
-            .array => return encode(arena, &input),
+            .Array => return encode(arena, &input),
 
-            .pointer => |info| switch (info.size) {
-                .one => switch (@typeInfo(info.child)) {
-                    .array => |child_info| {
+            .Pointer => |info| switch (info.size) {
+                .One => switch (@typeInfo(info.child)) {
+                    .Array => |child_info| {
                         const Slice = []const child_info.child;
                         return encode(arena, @as(Slice, input));
                     },
@@ -276,7 +276,7 @@ pub const Value = union(enum) {
                         @compileError("Unhandled type: {s}" ++ @typeName(info.child));
                     },
                 },
-                .slice => {
+                .Slice => {
                     if (info.child == u8) {
                         return Value{ .string = try arena.dupe(u8, input) };
                     }
@@ -303,9 +303,9 @@ pub const Value = union(enum) {
 
             // TODO we should probably have an option to encode `null` and also
             // allow for some default value too.
-            .optional => return if (input) |val| encode(arena, val) else null,
+            .Optional => return if (input) |val| encode(arena, val) else null,
 
-            .null => return null,
+            .Null => return null,
 
             else => {
                 @compileError("Unhandled type: {s}" ++ @typeName(@TypeOf(input)));
@@ -358,7 +358,7 @@ pub const Yaml = struct {
 
     pub fn parse(self: *Yaml, comptime T: type) Error!T {
         if (self.docs.items.len == 0) {
-            if (@typeInfo(T) == .void) return {};
+            if (@typeInfo(T) == .Void) return {};
             return error.TypeMismatch;
         }
 
@@ -367,16 +367,16 @@ pub const Yaml = struct {
         }
 
         switch (@typeInfo(T)) {
-            .array => |info| {
+            .Array => |info| {
                 var parsed: T = undefined;
                 for (self.docs.items, 0..) |doc, i| {
                     parsed[i] = try self.parseValue(info.child, doc);
                 }
                 return parsed;
             },
-            .pointer => |info| {
+            .Pointer => |info| {
                 switch (info.size) {
-                    .slice => {
+                    .Slice => {
                         var parsed = try self.arena.allocator().alloc(info.child, self.docs.items.len);
                         for (self.docs.items, 0..) |doc, i| {
                             parsed[i] = try self.parseValue(info.child, doc);
@@ -386,30 +386,30 @@ pub const Yaml = struct {
                     else => return error.TypeMismatch,
                 }
             },
-            .@"union" => return error.Unimplemented,
+            .Union => return error.Unimplemented,
             else => return error.TypeMismatch,
         }
     }
 
     fn parseValue(self: *Yaml, comptime T: type, value: Value) Error!T {
         return switch (@typeInfo(T)) {
-            .int => math.cast(T, try value.asInt()) orelse return error.Overflow,
-            .bool => self.parseBoolean(bool, value),
-            .float => if (value.asFloat()) |float| {
+            .Int => math.cast(T, try value.asInt()) orelse return error.Overflow,
+            .Bool => self.parseBoolean(bool, value),
+            .Float => if (value.asFloat()) |float| {
                 return math.lossyCast(T, float);
             } else |_| {
                 return math.lossyCast(T, try value.asInt());
             },
-            .@"struct" => self.parseStruct(T, try value.asMap()),
-            .@"union" => self.parseUnion(T, value),
-            .array => self.parseArray(T, try value.asList()),
-            .pointer => if (value.asList()) |list| {
+            .Struct => self.parseStruct(T, try value.asMap()),
+            .Union => self.parseUnion(T, value),
+            .Array => self.parseArray(T, try value.asList()),
+            .Pointer => if (value.asList()) |list| {
                 return self.parsePointer(T, .{ .list = list });
             } else |_| {
                 return self.parsePointer(T, .{ .string = try value.asString() });
             },
-            .void => error.TypeMismatch,
-            .optional => unreachable,
+            .Void => error.TypeMismatch,
+            .Optional => unreachable,
             else => error.Unimplemented,
         };
     }
@@ -420,7 +420,7 @@ pub const Yaml = struct {
     }
 
     fn parseUnion(self: *Yaml, comptime T: type, value: Value) Error!T {
-        const union_info = @typeInfo(T).@"union";
+        const union_info = @typeInfo(T).Union;
 
         if (union_info.tag_type) |_| {
             inline for (union_info.fields) |field| {
@@ -439,12 +439,12 @@ pub const Yaml = struct {
 
     fn parseOptional(self: *Yaml, comptime T: type, value: ?Value) Error!T {
         const unwrapped = value orelse return null;
-        const opt_info = @typeInfo(T).optional;
+        const opt_info = @typeInfo(T).Optional;
         return @as(T, try self.parseValue(opt_info.child, unwrapped));
     }
 
     fn parseStruct(self: *Yaml, comptime T: type, map: Map) Error!T {
-        const struct_info = @typeInfo(T).@"struct";
+        const struct_info = @typeInfo(T).Struct;
         var parsed: T = undefined;
 
         inline for (struct_info.fields) |field| {
@@ -453,7 +453,7 @@ pub const Yaml = struct {
                 break :blk map.get(field_name);
             };
 
-            if (@typeInfo(field.type) == .optional) {
+            if (@typeInfo(field.type) == .Optional) {
                 @field(parsed, field.name) = try self.parseOptional(field.type, value);
                 continue;
             }
@@ -469,11 +469,11 @@ pub const Yaml = struct {
     }
 
     fn parsePointer(self: *Yaml, comptime T: type, value: Value) Error!T {
-        const ptr_info = @typeInfo(T).pointer;
+        const ptr_info = @typeInfo(T).Pointer;
         const arena = self.arena.allocator();
 
         switch (ptr_info.size) {
-            .slice => {
+            .Slice => {
                 if (ptr_info.child == u8) {
                     return value.asString();
                 }
@@ -489,7 +489,7 @@ pub const Yaml = struct {
     }
 
     fn parseArray(self: *Yaml, comptime T: type, list: List) Error!T {
-        const array_info = @typeInfo(T).array;
+        const array_info = @typeInfo(T).Array;
         if (array_info.len != list.len) return error.ArraySizeMismatch;
 
         var parsed: T = undefined;

--- a/test/spec.zig
+++ b/test/spec.zig
@@ -69,9 +69,7 @@ const Testcase = struct {
     tags: std.BufSet,
 };
 
-fn make(step: *Step, make_options: Step.MakeOptions) !void {
-    _ = make_options;
-
+fn make(step: *Step, _: std.Progress.Node) !void {
     const spec_test: *SpecTest = @fieldParentPtr("step", step);
     const b = step.owner;
 


### PR DESCRIPTION
Hello! I have tried to run
```
zig build

zig build test -Denable-spec-tests (previously I had inited submodules)
```
And catch error:
```
...../zig-yaml/test/spec.zig:72:40: error: root struct of file 'Build.Step' has no member named 'MakeOptions'
fn make(step: *Step, make_options: Step.MakeOptions) !void {
                                   ~~~~^~~~~~~~~~~~
/snap/zig/11625/lib/std/Build/Step.zig:1:1: note: struct declared here
id: Id,
^~
referenced by:
    create: .../zig-yaml/test/spec.zig:50:101
    build: .../zig-yaml/build.zig:55:29
    remaining reference traces hidden; use '-freference-trace' to see all reference traces
```

I checked documentation and found out that 'make' function should have such prototype
```
pub const MakeFn = *const fn (step: *Step, prog_node: std.Progress.Node) anyerror!void
```

So I fix prototype. And now ```zig build``` works. Also I think that issue #30 about that problem. 

PS:
But there are errors after that fix if you run ```zig build test -Denable-spec-tests```.
```
src/yaml.zig:230:14: error: no field named 'float' in enum '@typeInfo(builtin.Type).Union.tag_type.?'
            .float => return Value{ .float = math.lossyCast(f64, input) },
```
Maybe such errors are  expected, idk. If it isn't I can try to research that problem (if you have any ideas about it, tell me pls).
I would appreciate any comments or explanations if I don't understand something or if I'm wrong.
