### PR TITLE
Embrace data-oriented design approach for managing parser's output

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -48,7 +48,7 @@ pub fn build(b: *std.Build) void {
         .optimize = optimize,
     });
     e2e_tests.root_module.addImport("yaml", yaml_module);
-    test_step.dependOn(&b.addRunArtifact(e2e_tests).step);
+    // test_step.dependOn(&b.addRunArtifact(e2e_tests).step);
 
     const enable_spec_tests = b.option(bool, "enable-spec-tests", "Enable YAML Test Suite") orelse false;
     if (enable_spec_tests) {

--- a/build.zig
+++ b/build.zig
@@ -48,7 +48,7 @@ pub fn build(b: *std.Build) void {
         .optimize = optimize,
     });
     e2e_tests.root_module.addImport("yaml", yaml_module);
-    // test_step.dependOn(&b.addRunArtifact(e2e_tests).step);
+    test_step.dependOn(&b.addRunArtifact(e2e_tests).step);
 
     const enable_spec_tests = b.option(bool, "enable-spec-tests", "Enable YAML Test Suite") orelse false;
     if (enable_spec_tests) {

--- a/flake.lock
+++ b/flake.lock
@@ -89,11 +89,11 @@
         "systems": "systems_3"
       },
       "locked": {
-        "lastModified": 1731533236,
-        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
+        "lastModified": 1705309234,
+        "narHash": "sha256-uNRRNRKmJyCRC/8y1RqBkqWBLM034y4qN7EprSdmgyA=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
+        "rev": "1ef2e671c3b0c19053962c07dbda38332dcebf26",
         "type": "github"
       },
       "original": {
@@ -125,11 +125,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1738843498,
-        "narHash": "sha256-7x+Q4xgFj9UxZZO9aUDCR8h4vyYut4zPUvfj3i+jBHE=",
+        "lastModified": 1739758141,
+        "narHash": "sha256-uq6A2L7o1/tR6VfmYhZWoVAwb3gTy7j4Jx30MIrH0rE=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "f5a32fa27df91dfc4b762671a0e0a859a8a0058f",
+        "rev": "c618e28f70257593de75a7044438efc1c1fc0791",
         "type": "github"
       },
       "original": {
@@ -157,11 +157,11 @@
     },
     "nixpkgs_3": {
       "locked": {
-        "lastModified": 1738702386,
-        "narHash": "sha256-nJj8f78AYAxl/zqLiFGXn5Im1qjFKU8yBPKoWEeZN5M=",
+        "lastModified": 1739206421,
+        "narHash": "sha256-PwQASeL2cGVmrtQYlrBur0U20Xy07uSWVnFup2PHnDs=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "030ba1976b7c0e1a67d9716b17308ccdab5b381e",
+        "rev": "44534bc021b85c8d78e465021e21f33b856e2540",
         "type": "github"
       },
       "original": {
@@ -232,11 +232,11 @@
         "nixpkgs": "nixpkgs_2"
       },
       "locked": {
-        "lastModified": 1739103017,
-        "narHash": "sha256-m3ueEW3eC6rw/VomahAc6hLlu+OPETeDM1HzJplwt2I=",
+        "lastModified": 1739838578,
+        "narHash": "sha256-3Oa3IXDVWMSIaaRNgusJNSzVDj0uCb2fZXChS0jnUq0=",
         "owner": "mitchellh",
         "repo": "zig-overlay",
-        "rev": "170bf6c6780b0abc9a642d90e40d983b124a6e55",
+        "rev": "b1190ae3077baed223b79e54c0164dd51e63631a",
         "type": "github"
       },
       "original": {
@@ -255,11 +255,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1738843894,
-        "narHash": "sha256-FIRuiy88r2g4YOokfjDzOxw38oNvzwF5YU9DZP1VWXw=",
+        "lastModified": 1739275930,
+        "narHash": "sha256-Tc8LiHKWpO0VHwoUb3aLf6Fp1exjGbqK0RdbUmCYw58=",
         "owner": "mitchellh",
         "repo": "zig-overlay",
-        "rev": "a4224598ba5e7d30a3cae355a7f43181deb346cb",
+        "rev": "163ae88f737f998b272e19c98ca6ce9a2aa02441",
         "type": "github"
       },
       "original": {
@@ -275,11 +275,11 @@
         "zig-overlay": "zig-overlay"
       },
       "locked": {
-        "lastModified": 1739036797,
-        "narHash": "sha256-SPbKBKYuKiOArJZAY8LGLw2QCE4G0bQ7HAekk36DxNw=",
+        "lastModified": 1739844671,
+        "narHash": "sha256-pD/4a2xN4sO3ypVc4A2dL9Su0yIBuu9FCO2nt2xVGOk=",
         "owner": "zigtools",
         "repo": "zls",
-        "rev": "4b4aafc4f90c55fb4041ba34ec9d4e8ba9c17d08",
+        "rev": "7f367a64106d4eb2dc3656e24a1a4370358080ec",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -19,6 +19,22 @@
     "flake-compat_2": {
       "flake": false,
       "locked": {
+        "lastModified": 1733328505,
+        "narHash": "sha256-NeCCThCEP3eCl2l/+27kNNK7QrwZB1IJCrXfrbv5oqU=",
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "rev": "ff81ac966bb2cae68946d5ed5fc4994f96d0ffec",
+        "type": "github"
+      },
+      "original": {
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "type": "github"
+      }
+    },
+    "flake-compat_3": {
+      "flake": false,
+      "locked": {
         "lastModified": 1696426674,
         "narHash": "sha256-kvjfFW7WAETZlt09AgDn1MrtKzP7t90Vf7vypd3OL1U=",
         "owner": "edolstra",
@@ -32,7 +48,39 @@
         "type": "github"
       }
     },
-    "flake-compat_3": {
+    "flake-compat_4": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1696426674,
+        "narHash": "sha256-kvjfFW7WAETZlt09AgDn1MrtKzP7t90Vf7vypd3OL1U=",
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "rev": "0f9255e01c2351cc7d116c072cb317785dd33b33",
+        "type": "github"
+      },
+      "original": {
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "type": "github"
+      }
+    },
+    "flake-compat_5": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1696426674,
+        "narHash": "sha256-kvjfFW7WAETZlt09AgDn1MrtKzP7t90Vf7vypd3OL1U=",
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "rev": "0f9255e01c2351cc7d116c072cb317785dd33b33",
+        "type": "github"
+      },
+      "original": {
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "type": "github"
+      }
+    },
+    "flake-compat_6": {
       "flake": false,
       "locked": {
         "lastModified": 1696426674,
@@ -71,11 +119,11 @@
         "systems": "systems_2"
       },
       "locked": {
-        "lastModified": 1705309234,
-        "narHash": "sha256-uNRRNRKmJyCRC/8y1RqBkqWBLM034y4qN7EprSdmgyA=",
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "1ef2e671c3b0c19053962c07dbda38332dcebf26",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
         "type": "github"
       },
       "original": {
@@ -102,7 +150,83 @@
         "type": "github"
       }
     },
+    "flake-utils_4": {
+      "inputs": {
+        "systems": "systems_4"
+      },
+      "locked": {
+        "lastModified": 1705309234,
+        "narHash": "sha256-uNRRNRKmJyCRC/8y1RqBkqWBLM034y4qN7EprSdmgyA=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "1ef2e671c3b0c19053962c07dbda38332dcebf26",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "flake-utils_5": {
+      "inputs": {
+        "systems": "systems_5"
+      },
+      "locked": {
+        "lastModified": 1705309234,
+        "narHash": "sha256-uNRRNRKmJyCRC/8y1RqBkqWBLM034y4qN7EprSdmgyA=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "1ef2e671c3b0c19053962c07dbda38332dcebf26",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "flake-utils_6": {
+      "inputs": {
+        "systems": "systems_6"
+      },
+      "locked": {
+        "lastModified": 1705309234,
+        "narHash": "sha256-uNRRNRKmJyCRC/8y1RqBkqWBLM034y4qN7EprSdmgyA=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "1ef2e671c3b0c19053962c07dbda38332dcebf26",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
     "gitignore": {
+      "inputs": {
+        "nixpkgs": [
+          "poop",
+          "zls",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1709087332,
+        "narHash": "sha256-HG2cCnktfHsKV0s4XW83gU3F57gaTljL9KNSuG6bnQs=",
+        "owner": "hercules-ci",
+        "repo": "gitignore.nix",
+        "rev": "637db329424fd7e46cf4185293b9cc8c88c95394",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hercules-ci",
+        "repo": "gitignore.nix",
+        "type": "github"
+      }
+    },
+    "gitignore_2": {
       "inputs": {
         "nixpkgs": [
           "zls",
@@ -141,6 +265,22 @@
     },
     "nixpkgs_2": {
       "locked": {
+        "lastModified": 1739758141,
+        "narHash": "sha256-uq6A2L7o1/tR6VfmYhZWoVAwb3gTy7j4Jx30MIrH0rE=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "c618e28f70257593de75a7044438efc1c1fc0791",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "ref": "nixos-24.11",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_3": {
+      "locked": {
         "lastModified": 1708161998,
         "narHash": "sha256-6KnemmUorCvlcAvGziFosAVkrlWZGIc6UNT9GUYr0jQ=",
         "owner": "NixOS",
@@ -155,7 +295,7 @@
         "type": "github"
       }
     },
-    "nixpkgs_3": {
+    "nixpkgs_4": {
       "locked": {
         "lastModified": 1739206421,
         "narHash": "sha256-PwQASeL2cGVmrtQYlrBur0U20Xy07uSWVnFup2PHnDs=",
@@ -171,13 +311,69 @@
         "type": "github"
       }
     },
+    "nixpkgs_5": {
+      "locked": {
+        "lastModified": 1708161998,
+        "narHash": "sha256-6KnemmUorCvlcAvGziFosAVkrlWZGIc6UNT9GUYr0jQ=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "84d981bae8b5e783b3b548de505b22880559515f",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-23.11",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_6": {
+      "locked": {
+        "lastModified": 1739206421,
+        "narHash": "sha256-PwQASeL2cGVmrtQYlrBur0U20Xy07uSWVnFup2PHnDs=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "44534bc021b85c8d78e465021e21f33b856e2540",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-24.11",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "poop": {
+      "inputs": {
+        "flake-compat": "flake-compat_2",
+        "flake-utils": "flake-utils_2",
+        "nixpkgs": "nixpkgs_2",
+        "zig": "zig",
+        "zls": "zls"
+      },
+      "locked": {
+        "lastModified": 1739946927,
+        "narHash": "sha256-07xFvrm46RsQL81Mn2VMRRuU2//4VKs/V4G6n203OUQ=",
+        "owner": "kubkon",
+        "repo": "poop",
+        "rev": "2007a7e1dcc9c08b878d513bba27cdfb91991622",
+        "type": "github"
+      },
+      "original": {
+        "owner": "kubkon",
+        "ref": "nix",
+        "repo": "poop",
+        "type": "github"
+      }
+    },
     "root": {
       "inputs": {
         "flake-compat": "flake-compat",
         "flake-utils": "flake-utils",
         "nixpkgs": "nixpkgs",
-        "zig": "zig",
-        "zls": "zls"
+        "poop": "poop",
+        "zig": "zig_2",
+        "zls": "zls_2"
       }
     },
     "systems": {
@@ -225,18 +421,63 @@
         "type": "github"
       }
     },
+    "systems_4": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    },
+    "systems_5": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    },
+    "systems_6": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    },
     "zig": {
       "inputs": {
-        "flake-compat": "flake-compat_2",
-        "flake-utils": "flake-utils_2",
-        "nixpkgs": "nixpkgs_2"
+        "flake-compat": "flake-compat_3",
+        "flake-utils": "flake-utils_3",
+        "nixpkgs": "nixpkgs_3"
       },
       "locked": {
-        "lastModified": 1739838578,
-        "narHash": "sha256-3Oa3IXDVWMSIaaRNgusJNSzVDj0uCb2fZXChS0jnUq0=",
+        "lastModified": 1739924999,
+        "narHash": "sha256-EHOOMs8bnmRO+tCmZ+ZeDi6VbQykISfpkknxkGPpOjA=",
         "owner": "mitchellh",
         "repo": "zig-overlay",
-        "rev": "b1190ae3077baed223b79e54c0164dd51e63631a",
+        "rev": "6a43a4acb17ddcb72d222e1dbf8732a8e46e9b41",
         "type": "github"
       },
       "original": {
@@ -247,8 +488,32 @@
     },
     "zig-overlay": {
       "inputs": {
-        "flake-compat": "flake-compat_3",
-        "flake-utils": "flake-utils_3",
+        "flake-compat": "flake-compat_4",
+        "flake-utils": "flake-utils_4",
+        "nixpkgs": [
+          "poop",
+          "zls",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1739275930,
+        "narHash": "sha256-Tc8LiHKWpO0VHwoUb3aLf6Fp1exjGbqK0RdbUmCYw58=",
+        "owner": "mitchellh",
+        "repo": "zig-overlay",
+        "rev": "163ae88f737f998b272e19c98ca6ce9a2aa02441",
+        "type": "github"
+      },
+      "original": {
+        "owner": "mitchellh",
+        "repo": "zig-overlay",
+        "type": "github"
+      }
+    },
+    "zig-overlay_2": {
+      "inputs": {
+        "flake-compat": "flake-compat_6",
+        "flake-utils": "flake-utils_6",
         "nixpkgs": [
           "zls",
           "nixpkgs"
@@ -268,11 +533,51 @@
         "type": "github"
       }
     },
+    "zig_2": {
+      "inputs": {
+        "flake-compat": "flake-compat_5",
+        "flake-utils": "flake-utils_5",
+        "nixpkgs": "nixpkgs_5"
+      },
+      "locked": {
+        "lastModified": 1739924999,
+        "narHash": "sha256-EHOOMs8bnmRO+tCmZ+ZeDi6VbQykISfpkknxkGPpOjA=",
+        "owner": "mitchellh",
+        "repo": "zig-overlay",
+        "rev": "6a43a4acb17ddcb72d222e1dbf8732a8e46e9b41",
+        "type": "github"
+      },
+      "original": {
+        "owner": "mitchellh",
+        "repo": "zig-overlay",
+        "type": "github"
+      }
+    },
     "zls": {
       "inputs": {
         "gitignore": "gitignore",
-        "nixpkgs": "nixpkgs_3",
+        "nixpkgs": "nixpkgs_4",
         "zig-overlay": "zig-overlay"
+      },
+      "locked": {
+        "lastModified": 1739844671,
+        "narHash": "sha256-pD/4a2xN4sO3ypVc4A2dL9Su0yIBuu9FCO2nt2xVGOk=",
+        "owner": "zigtools",
+        "repo": "zls",
+        "rev": "7f367a64106d4eb2dc3656e24a1a4370358080ec",
+        "type": "github"
+      },
+      "original": {
+        "owner": "zigtools",
+        "repo": "zls",
+        "type": "github"
+      }
+    },
+    "zls_2": {
+      "inputs": {
+        "gitignore": "gitignore_2",
+        "nixpkgs": "nixpkgs_6",
+        "zig-overlay": "zig-overlay_2"
       },
       "locked": {
         "lastModified": 1739844671,

--- a/flake.nix
+++ b/flake.nix
@@ -6,6 +6,7 @@
     flake-utils.url = "github:numtide/flake-utils";
     zig.url = "github:mitchellh/zig-overlay";
     zls.url = "github:zigtools/zls";
+    poop.url = "github:kubkon/poop/nix";
 
     # Used for shell.nix
     flake-compat = {
@@ -27,6 +28,7 @@
         (final: prev: {
           zigpkgs = inputs.zig.packages.${prev.system};
           zlspkgs = inputs.zls.packages.${prev.system};
+          pooppkgs = inputs.poop.packages.${prev.system};
         })
       ];
 
@@ -44,6 +46,7 @@
           nativeBuildInputs = with pkgs; [
             zigpkgs.master
             zlspkgs.default
+            pooppkgs.default
           ];
         };
 

--- a/src/parse.zig
+++ b/src/parse.zig
@@ -8,6 +8,52 @@ const Tokenizer = @import("Tokenizer.zig");
 const Token = Tokenizer.Token;
 const TokenIterator = Tokenizer.TokenIterator;
 
+/// TODO for each Node we need to track start-end Tokens too.
+pub const Node2 = struct {
+    tag: Tag,
+    data: Data,
+
+    pub const Tag = enum(u8) {
+        /// Comprises an index into another Node.
+        /// Payload is doc.
+        doc,
+
+        /// Doc with directive.
+        /// Payload is doc_payload, where extra payload is Directive.
+        doc_directive,
+
+        /// Comprises an index into extras where payload is Map.
+        map,
+        list,
+        value,
+    };
+
+    pub const Data = union {
+        doc: Index,
+
+        doc_payload: struct {
+            value: Index,
+            payload: u32,
+        },
+    };
+
+    pub const Index = enum(u32) {
+        _,
+    };
+
+    // Make sure we don't accidentally make nodes bigger than expected.
+    // Note that in safety builds, Zig is allowed to insert a secret field for safety checks.
+    comptime {
+        if (!std.debug.runtime_safety) {
+            assert(@sizeOf(Data) == 8);
+        }
+    }
+};
+
+pub const Directive = struct {
+    token_index: Token.Index,
+};
+
 pub const ParseError = error{
     InvalidEscapeSequence,
     MalformedYaml,

--- a/src/parse/test.zig
+++ b/src/parse/test.zig
@@ -14,9 +14,9 @@ fn expectNodeScope(tree: Tree, node: Node.Index, from: usize, to: usize) !void {
 }
 
 fn expectValueMapEntry(tree: Tree, entry_data: parse.Map.Entry, exp_key: []const u8, exp_value: []const u8) !void {
-    const key = tree.getToken(entry_data.key);
+    const key = tree.token(entry_data.key);
     try testing.expectEqual(key.id, .literal);
-    try testing.expectEqualStrings(exp_key, tree.getRaw(entry_data.key, entry_data.key));
+    try testing.expectEqualStrings(exp_key, tree.rawString(entry_data.key, entry_data.key));
 
     const maybe_value = entry_data.maybe_node;
     try testing.expect(maybe_value != .none);
@@ -24,14 +24,14 @@ fn expectValueMapEntry(tree: Tree, entry_data: parse.Map.Entry, exp_key: []const
 
     const value = maybe_value.unwrap().?;
     const scope = tree.nodeScope(value);
-    const string = tree.getRaw(scope.start, scope.end);
+    const string = tree.rawString(scope.start, scope.end);
     try testing.expectEqualStrings(exp_value, string);
 }
 
 fn expectStringValueMapEntry(tree: Tree, entry_data: parse.Map.Entry, exp_key: []const u8, exp_value: []const u8) !void {
-    const key = tree.getToken(entry_data.key);
+    const key = tree.token(entry_data.key);
     try testing.expectEqual(key.id, .literal);
-    try testing.expectEqualStrings(exp_key, tree.getRaw(entry_data.key, entry_data.key));
+    try testing.expectEqualStrings(exp_key, tree.rawString(entry_data.key, entry_data.key));
 
     const maybe_value = entry_data.maybe_node;
     try testing.expect(maybe_value != .none);
@@ -47,7 +47,7 @@ fn expectValueListEntry(tree: Tree, entry_data: parse.List.Entry, exp_value: []c
     try testing.expectEqual(.value, tree.nodeTag(value));
 
     const scope = tree.nodeScope(value);
-    const string = tree.getRaw(scope.start, scope.end);
+    const string = tree.rawString(scope.start, scope.end);
     try testing.expectEqualStrings(exp_value, string);
 }
 
@@ -84,7 +84,7 @@ test "explicit doc" {
 
     try expectNodeScope(tree, doc, 0, tree.tokens.len - 2);
 
-    const directive = tree.getDirective(doc).?;
+    const directive = tree.directive(doc).?;
     try testing.expectEqualStrings("tapi-tbd", directive);
 
     const doc_value = tree.nodeData(doc).doc_with_directive.maybe_node;
@@ -182,9 +182,9 @@ test "nested maps" {
 
     var entry_data = tree.extraData(parse.Map.Entry, map_data.end);
     {
-        const key = tree.getToken(entry_data.data.key);
+        const key = tree.token(entry_data.data.key);
         try testing.expectEqual(key.id, .literal);
-        try testing.expectEqualStrings("key1", tree.getRaw(entry_data.data.key, entry_data.data.key));
+        try testing.expectEqualStrings("key1", tree.rawString(entry_data.data.key, entry_data.data.key));
 
         const maybe_nested_map = entry_data.data.maybe_node;
         try testing.expect(maybe_nested_map != .none);
@@ -239,9 +239,9 @@ test "map of list of values" {
     const map_data = tree.nodeData(map).map;
 
     {
-        const key = tree.getToken(map_data.key);
+        const key = tree.token(map_data.key);
         try testing.expectEqual(key.id, .literal);
-        try testing.expectEqualStrings("ints", tree.getRaw(map_data.key, map_data.key));
+        try testing.expectEqualStrings("ints", tree.rawString(map_data.key, map_data.key));
 
         const maybe_nested_list = map_data.maybe_node;
         try testing.expect(maybe_nested_list != .none);
@@ -296,9 +296,9 @@ test "map of list of maps" {
     const map_data = tree.nodeData(map).map;
 
     {
-        const key = tree.getToken(map_data.key);
+        const key = tree.token(map_data.key);
         try testing.expectEqual(key.id, .literal);
-        try testing.expectEqualStrings("key1", tree.getRaw(map_data.key, map_data.key));
+        try testing.expectEqualStrings("key1", tree.rawString(map_data.key, map_data.key));
 
         const maybe_nested_list = map_data.maybe_node;
         try testing.expect(maybe_nested_list != .none);
@@ -356,9 +356,9 @@ test "map of list of maps with inner list" {
     const map_data = tree.nodeData(map).map;
 
     {
-        const key = tree.getToken(map_data.key);
+        const key = tree.token(map_data.key);
         try testing.expectEqual(key.id, .literal);
-        try testing.expectEqualStrings("outer", tree.getRaw(map_data.key, map_data.key));
+        try testing.expectEqualStrings("outer", tree.rawString(map_data.key, map_data.key));
 
         const maybe_nested_list = map_data.maybe_node;
         try testing.expect(maybe_nested_list != .none);
@@ -383,9 +383,9 @@ test "map of list of maps with inner list" {
             nested_nested_entry_data = tree.extraData(parse.Map.Entry, nested_nested_entry_data.end);
             {
                 const nested_nested_map_entry = nested_nested_entry_data.data;
-                const nested_nested_key = tree.getToken(nested_nested_map_entry.key);
+                const nested_nested_key = tree.token(nested_nested_map_entry.key);
                 try testing.expectEqual(nested_nested_key.id, .literal);
-                try testing.expectEqualStrings("fooers", tree.getRaw(nested_nested_map_entry.key, nested_nested_map_entry.key));
+                try testing.expectEqualStrings("fooers", tree.rawString(nested_nested_map_entry.key, nested_nested_map_entry.key));
 
                 const nested_nested_value = nested_nested_map_entry.maybe_node;
                 try testing.expect(nested_nested_value != .none);
@@ -410,9 +410,9 @@ test "map of list of maps with inner list" {
             nested_nested_entry_data = tree.extraData(parse.Map.Entry, nested_nested_entry_data.end);
             {
                 const nested_nested_map_entry = nested_nested_entry_data.data;
-                const nested_nested_key = tree.getToken(nested_nested_map_entry.key);
+                const nested_nested_key = tree.token(nested_nested_map_entry.key);
                 try testing.expectEqual(nested_nested_key.id, .literal);
-                try testing.expectEqualStrings("fooers", tree.getRaw(nested_nested_map_entry.key, nested_nested_map_entry.key));
+                try testing.expectEqualStrings("fooers", tree.rawString(nested_nested_map_entry.key, nested_nested_map_entry.key));
 
                 const nested_nested_value = nested_nested_map_entry.maybe_node;
                 try testing.expect(nested_nested_value != .none);
@@ -581,9 +581,9 @@ test "inline list as mapping value" {
 
     const map_data = tree.nodeData(map).map;
 
-    const key = tree.getToken(map_data.key);
+    const key = tree.token(map_data.key);
     try testing.expectEqual(key.id, .literal);
-    try testing.expectEqualStrings("key", tree.getRaw(map_data.key, map_data.key));
+    try testing.expectEqualStrings("key", tree.rawString(map_data.key, map_data.key));
 
     const maybe_nested_list = map_data.maybe_node;
     try testing.expect(maybe_nested_list != .none);

--- a/src/parse/test.zig
+++ b/src/parse/test.zig
@@ -7,8 +7,8 @@ const Node = parse.Node;
 const Parser = parse.Parser;
 const Tree = parse.Tree;
 
-fn expectNodeScope(parser: Parser, node: Node.Index, from: usize, to: usize) !void {
-    const scope = parser.nodes_scopes.get(node).?;
+fn expectNodeScope(tree: Tree, node: Node.Index, from: usize, to: usize) !void {
+    const scope = tree.nodeScope(node);
     try testing.expectEqual(from, @intFromEnum(scope.start));
     try testing.expectEqual(to, @intFromEnum(scope.end));
 }
@@ -66,7 +66,7 @@ test "explicit doc" {
     const doc = tree.docs[0];
     try testing.expectEqual(.doc_with_directive, tree.nodeTag(doc));
 
-    try expectNodeScope(parser, doc, 0, tree.tokens.len - 2);
+    try expectNodeScope(tree, doc, 0, tree.tokens.len - 2);
 
     const directive = tree.getDirective(doc).?;
     try testing.expectEqualStrings("tapi-tbd", directive);
@@ -77,7 +77,7 @@ test "explicit doc" {
 
     const map = doc_value.unwrap().?;
 
-    try expectNodeScope(parser, map, 5, 14);
+    try expectNodeScope(tree, map, 5, 14);
 
     const map_data = tree.extraData(parse.Map, tree.nodeData(map).extra);
     try testing.expectEqual(2, map_data.data.map_len);
@@ -108,7 +108,7 @@ test "leaf in quotes" {
     const doc = tree.docs[0];
     try testing.expectEqual(.doc, tree.nodeTag(doc));
 
-    try expectNodeScope(parser, doc, 0, tree.tokens.len - 2);
+    try expectNodeScope(tree, doc, 0, tree.tokens.len - 2);
 
     const doc_value = tree.nodeData(doc).maybe_node;
     try testing.expect(doc_value != .none);
@@ -116,7 +116,7 @@ test "leaf in quotes" {
 
     const map = doc_value.unwrap().?;
 
-    try expectNodeScope(parser, map, 0, tree.tokens.len - 2);
+    try expectNodeScope(tree, map, 0, tree.tokens.len - 2);
 
     const map_data = tree.extraData(parse.Map, tree.nodeData(map).extra);
     try testing.expectEqual(3, map_data.data.map_len);
@@ -151,7 +151,7 @@ test "nested maps" {
     const doc = tree.docs[0];
     try testing.expectEqual(.doc, tree.nodeTag(doc));
 
-    try expectNodeScope(parser, doc, 0, tree.tokens.len - 2);
+    try expectNodeScope(tree, doc, 0, tree.tokens.len - 2);
 
     const doc_value = tree.nodeData(doc).maybe_node;
     try testing.expect(doc_value != .none);
@@ -159,7 +159,7 @@ test "nested maps" {
 
     const map = doc_value.unwrap().?;
 
-    try expectNodeScope(parser, map, 0, tree.tokens.len - 2);
+    try expectNodeScope(tree, map, 0, tree.tokens.len - 2);
 
     const map_data = tree.extraData(parse.Map, tree.nodeData(map).extra);
     try testing.expectEqual(2, map_data.data.map_len);
@@ -176,7 +176,7 @@ test "nested maps" {
 
         const nested_map = maybe_nested_map.unwrap().?;
 
-        try expectNodeScope(parser, nested_map, 4, 16);
+        try expectNodeScope(tree, nested_map, 4, 16);
 
         const nested_map_data = tree.extraData(parse.Map, tree.nodeData(nested_map).extra);
         try testing.expectEqual(2, nested_map_data.data.map_len);
@@ -210,7 +210,7 @@ test "map of list of values" {
     try testing.expectEqual(1, tree.docs.len);
 
     const doc = tree.docs[0];
-    try expectNodeScope(parser, doc, 0, tree.tokens.len - 2);
+    try expectNodeScope(tree, doc, 0, tree.tokens.len - 2);
 
     const doc_value = tree.nodeData(doc).maybe_node;
     try testing.expect(doc_value != .none);
@@ -218,7 +218,7 @@ test "map of list of values" {
 
     const map = doc_value.unwrap().?;
 
-    try expectNodeScope(parser, map, 0, tree.tokens.len - 2);
+    try expectNodeScope(tree, map, 0, tree.tokens.len - 2);
 
     const map_data = tree.nodeData(map).map;
 
@@ -233,7 +233,7 @@ test "map of list of values" {
 
         const nested_list = maybe_nested_list.unwrap().?;
 
-        try expectNodeScope(parser, nested_list, 4, tree.tokens.len - 2);
+        try expectNodeScope(tree, nested_list, 4, tree.tokens.len - 2);
 
         const nested_list_data = tree.extraData(parse.List, tree.nodeData(nested_list).extra);
         try testing.expectEqual(3, nested_list_data.data.list_len);
@@ -267,7 +267,7 @@ test "map of list of maps" {
     try testing.expectEqual(1, tree.docs.len);
 
     const doc = tree.docs[0];
-    try expectNodeScope(parser, doc, 0, tree.tokens.len - 2);
+    try expectNodeScope(tree, doc, 0, tree.tokens.len - 2);
 
     const doc_value = tree.nodeData(doc).maybe_node;
     try testing.expect(doc_value != .none);
@@ -275,7 +275,7 @@ test "map of list of maps" {
 
     const map = doc_value.unwrap().?;
 
-    try expectNodeScope(parser, map, 0, tree.tokens.len - 2);
+    try expectNodeScope(tree, map, 0, tree.tokens.len - 2);
 
     const map_data = tree.nodeData(map).map;
 
@@ -290,7 +290,7 @@ test "map of list of maps" {
 
         const nested_list = maybe_nested_list.unwrap().?;
 
-        try expectNodeScope(parser, nested_list, 3, tree.tokens.len - 2);
+        try expectNodeScope(tree, nested_list, 3, tree.tokens.len - 2);
 
         const nested_list_data = tree.extraData(parse.List, tree.nodeData(nested_list).extra);
         try testing.expectEqual(3, nested_list_data.data.list_len);
@@ -327,7 +327,7 @@ test "map of list of maps with inner list" {
     try testing.expectEqual(1, tree.docs.len);
 
     const doc = tree.docs[0];
-    try expectNodeScope(parser, doc, 1, tree.tokens.len - 2);
+    try expectNodeScope(tree, doc, 1, tree.tokens.len - 2);
 
     const doc_value = tree.nodeData(doc).maybe_node;
     try testing.expect(doc_value != .none);
@@ -335,7 +335,7 @@ test "map of list of maps with inner list" {
 
     const map = doc_value.unwrap().?;
 
-    try expectNodeScope(parser, map, 1, tree.tokens.len - 2);
+    try expectNodeScope(tree, map, 1, tree.tokens.len - 2);
 
     const map_data = tree.nodeData(map).map;
 
@@ -350,7 +350,7 @@ test "map of list of maps with inner list" {
 
         const nested_list = maybe_nested_list.unwrap().?;
 
-        try expectNodeScope(parser, nested_list, 5, tree.tokens.len - 2);
+        try expectNodeScope(tree, nested_list, 5, tree.tokens.len - 2);
 
         const nested_list_data = tree.nodeData(nested_list).list;
 
@@ -427,7 +427,7 @@ test "list of lists" {
     try testing.expectEqual(1, tree.docs.len);
 
     const doc = tree.docs[0];
-    try expectNodeScope(parser, doc, 0, tree.tokens.len - 2);
+    try expectNodeScope(tree, doc, 0, tree.tokens.len - 2);
 
     const doc_value = tree.nodeData(doc).maybe_node;
     try testing.expect(doc_value != .none);
@@ -435,7 +435,7 @@ test "list of lists" {
 
     const list = doc_value.unwrap().?;
 
-    try expectNodeScope(parser, list, 0, tree.tokens.len - 2);
+    try expectNodeScope(tree, list, 0, tree.tokens.len - 2);
 
     const list_data = tree.extraData(parse.List, tree.nodeData(list).extra);
     try testing.expectEqual(3, list_data.data.list_len);
@@ -444,7 +444,7 @@ test "list of lists" {
     {
         const nested_list = entry_data.data.node;
 
-        try expectNodeScope(parser, nested_list, 1, 11);
+        try expectNodeScope(tree, nested_list, 1, 11);
 
         const nested_list_data = tree.extraData(parse.List, tree.nodeData(nested_list).extra);
         try testing.expectEqual(3, nested_list_data.data.list_len);
@@ -463,7 +463,7 @@ test "list of lists" {
     {
         const nested_list = entry_data.data.node;
 
-        try expectNodeScope(parser, nested_list, 14, 25);
+        try expectNodeScope(tree, nested_list, 14, 25);
 
         const nested_list_data = tree.extraData(parse.List, tree.nodeData(nested_list).extra);
         try testing.expectEqual(3, nested_list_data.data.list_len);
@@ -482,7 +482,7 @@ test "list of lists" {
     {
         const nested_list = entry_data.data.node;
 
-        try expectNodeScope(parser, nested_list, 28, 39);
+        try expectNodeScope(tree, nested_list, 28, 39);
 
         const nested_list_data = tree.extraData(parse.List, tree.nodeData(nested_list).extra);
         try testing.expectEqual(3, nested_list_data.data.list_len);
@@ -513,7 +513,7 @@ test "inline list" {
     try testing.expectEqual(1, tree.docs.len);
 
     const doc = tree.docs[0];
-    try expectNodeScope(parser, doc, 0, tree.tokens.len - 2);
+    try expectNodeScope(tree, doc, 0, tree.tokens.len - 2);
 
     const doc_value = tree.nodeData(doc).maybe_node;
     try testing.expect(doc_value != .none);
@@ -521,7 +521,7 @@ test "inline list" {
 
     const list = doc_value.unwrap().?;
 
-    try expectNodeScope(parser, list, 0, tree.tokens.len - 2);
+    try expectNodeScope(tree, list, 0, tree.tokens.len - 2);
 
     const list_data = tree.extraData(parse.List, tree.nodeData(list).extra);
     try testing.expectEqual(3, list_data.data.list_len);
@@ -553,7 +553,7 @@ test "inline list as mapping value" {
     try testing.expectEqual(1, tree.docs.len);
 
     const doc = tree.docs[0];
-    try expectNodeScope(parser, doc, 0, tree.tokens.len - 2);
+    try expectNodeScope(tree, doc, 0, tree.tokens.len - 2);
 
     const doc_value = tree.nodeData(doc).maybe_node;
     try testing.expect(doc_value != .none);
@@ -561,7 +561,7 @@ test "inline list as mapping value" {
 
     const map = doc_value.unwrap().?;
 
-    try expectNodeScope(parser, map, 0, tree.tokens.len - 2);
+    try expectNodeScope(tree, map, 0, tree.tokens.len - 2);
 
     const map_data = tree.nodeData(map).map;
 
@@ -575,7 +575,7 @@ test "inline list as mapping value" {
 
     const nested_list = maybe_nested_list.unwrap().?;
 
-    try expectNodeScope(parser, nested_list, 4, tree.tokens.len - 2);
+    try expectNodeScope(tree, nested_list, 4, tree.tokens.len - 2);
 
     const nested_list_data = tree.extraData(parse.List, tree.nodeData(nested_list).extra);
     try testing.expectEqual(3, nested_list_data.data.list_len);

--- a/src/parse/test.zig
+++ b/src/parse/test.zig
@@ -23,6 +23,21 @@ fn expectValueMapEntry(tree: Tree, entry_data: parse.Map.Entry, exp_key: []const
     try testing.expectEqual(.value, tree.nodeTag(maybe_value.unwrap().?));
 
     const value = maybe_value.unwrap().?;
+    const scope = tree.nodeScope(value);
+    const string = tree.getRaw(scope.start, scope.end);
+    try testing.expectEqualStrings(exp_value, string);
+}
+
+fn expectStringValueMapEntry(tree: Tree, entry_data: parse.Map.Entry, exp_key: []const u8, exp_value: []const u8) !void {
+    const key = tree.getToken(entry_data.key);
+    try testing.expectEqual(key.id, .literal);
+    try testing.expectEqualStrings(exp_key, tree.getRaw(entry_data.key, entry_data.key));
+
+    const maybe_value = entry_data.maybe_node;
+    try testing.expect(maybe_value != .none);
+    try testing.expectEqual(.string_value, tree.nodeTag(maybe_value.unwrap().?));
+
+    const value = maybe_value.unwrap().?;
     const string = tree.nodeData(value).string.slice(tree);
     try testing.expectEqualStrings(exp_value, string);
 }
@@ -31,7 +46,8 @@ fn expectValueListEntry(tree: Tree, entry_data: parse.List.Entry, exp_value: []c
     const value = entry_data.node;
     try testing.expectEqual(.value, tree.nodeTag(value));
 
-    const string = tree.nodeData(value).string.slice(tree);
+    const scope = tree.nodeScope(value);
+    const string = tree.getRaw(scope.start, scope.end);
     try testing.expectEqualStrings(exp_value, string);
 }
 
@@ -125,10 +141,10 @@ test "leaf in quotes" {
     try expectValueMapEntry(tree, entry_data.data, "key1", "no quotes, comma");
 
     entry_data = tree.extraData(parse.Map.Entry, entry_data.end);
-    try expectValueMapEntry(tree, entry_data.data, "key2", "single quoted");
+    try expectStringValueMapEntry(tree, entry_data.data, "key2", "single quoted");
 
     entry_data = tree.extraData(parse.Map.Entry, entry_data.end);
-    try expectValueMapEntry(tree, entry_data.data, "key3", "double quoted");
+    try expectStringValueMapEntry(tree, entry_data.data, "key3", "double quoted");
 }
 
 test "nested maps" {

--- a/src/parse/test.zig
+++ b/src/parse/test.zig
@@ -7,7 +7,7 @@ const Node = parse.Node;
 const Parser = parse.Parser;
 const Tree = parse.Tree;
 
-fn expect_map_entry_with_string_value(
+fn expectMapEntryWithStringValue(
     tree: Tree,
     entry_data: parse.Map.Entry,
     exp_key: []const u8,
@@ -66,10 +66,10 @@ test "explicit doc" {
     try testing.expectEqual(2, map_data.data.map_len);
 
     var entry_data = tree.extraData(parse.Map.Entry, map_data.end);
-    try expect_map_entry_with_string_value(tree, entry_data.data, "tbd-version", "4");
+    try expectMapEntryWithStringValue(tree, entry_data.data, "tbd-version", "4");
 
     entry_data = tree.extraData(parse.Map.Entry, entry_data.end);
-    try expect_map_entry_with_string_value(tree, entry_data.data, "abc-version", "5");
+    try expectMapEntryWithStringValue(tree, entry_data.data, "abc-version", "5");
 }
 
 test "leaf in quotes" {
@@ -108,13 +108,13 @@ test "leaf in quotes" {
     try testing.expectEqual(3, map_data.data.map_len);
 
     var entry_data = tree.extraData(parse.Map.Entry, map_data.end);
-    try expect_map_entry_with_string_value(tree, entry_data.data, "key1", "no quotes, comma");
+    try expectMapEntryWithStringValue(tree, entry_data.data, "key1", "no quotes, comma");
 
     entry_data = tree.extraData(parse.Map.Entry, entry_data.end);
-    try expect_map_entry_with_string_value(tree, entry_data.data, "key2", "single quoted");
+    try expectMapEntryWithStringValue(tree, entry_data.data, "key2", "single quoted");
 
     entry_data = tree.extraData(parse.Map.Entry, entry_data.end);
-    try expect_map_entry_with_string_value(tree, entry_data.data, "key3", "double quoted");
+    try expectMapEntryWithStringValue(tree, entry_data.data, "key3", "double quoted");
 }
 
 test "nested maps" {
@@ -172,14 +172,14 @@ test "nested maps" {
         try testing.expectEqual(2, nested_map_data.data.map_len);
 
         var nested_entry_data = tree.extraData(parse.Map.Entry, nested_map_data.end);
-        try expect_map_entry_with_string_value(tree, nested_entry_data.data, "key1_1", "value1_1");
+        try expectMapEntryWithStringValue(tree, nested_entry_data.data, "key1_1", "value1_1");
 
         nested_entry_data = tree.extraData(parse.Map.Entry, nested_entry_data.end);
-        try expect_map_entry_with_string_value(tree, nested_entry_data.data, "key1_2", "value1_2");
+        try expectMapEntryWithStringValue(tree, nested_entry_data.data, "key1_2", "value1_2");
     }
 
     entry_data = tree.extraData(parse.Map.Entry, entry_data.end);
-    try expect_map_entry_with_string_value(tree, entry_data.data, "key2", "value2");
+    try expectMapEntryWithStringValue(tree, entry_data.data, "key2", "value2");
 }
 
 // test "map of list of values" {

--- a/src/parse/test.zig
+++ b/src/parse/test.zig
@@ -4,6 +4,7 @@ const testing = std.testing;
 const parse = @import("../parse.zig");
 
 const Node = parse.Node;
+const Parser = parse.Parser;
 const Tree = parse.Tree;
 
 test "explicit doc" {
@@ -14,867 +15,880 @@ test "explicit doc" {
         \\...
     ;
 
-    var tree = Tree.init(testing.allocator);
-    defer tree.deinit();
-    try tree.parse(source);
+    var parser: Parser = .{ .allocator = testing.allocator, .source = source };
+    defer parser.deinit();
+    try parser.parse();
 
-    try testing.expectEqual(tree.docs.items.len, 1);
+    var tree = try parser.toOwnedTree();
+    defer tree.deinit(testing.allocator);
 
-    const doc = tree.docs.items[0].cast(Node.Doc).?;
-    try testing.expectEqual(@intFromEnum(doc.base.start), 0);
-    try testing.expectEqual(@intFromEnum(doc.base.end), tree.tokens.len - 2);
+    try testing.expectEqual(1, tree.docs.len);
 
-    const directive = tree.getToken(doc.directive.?);
-    try testing.expectEqual(directive.id, .literal);
-    try testing.expectEqualStrings("tapi-tbd", tree.source[directive.loc.start..directive.loc.end]);
+    const doc = tree.docs[0];
+    try testing.expectEqual(.doc_with_directive, tree.nodeTag(doc));
 
-    try testing.expect(doc.value != null);
-    try testing.expectEqual(doc.value.?.tag, .map);
+    const doc_scope = parser.nodes_scopes.get(doc).?;
+    try testing.expectEqual(0, @intFromEnum(doc_scope.start));
+    try testing.expectEqual(tree.tokens.len - 2, @intFromEnum(doc_scope.end));
 
-    const map = doc.value.?.cast(Node.Map).?;
-    try testing.expectEqual(@intFromEnum(map.base.start), 5);
-    try testing.expectEqual(@intFromEnum(map.base.end), 14);
-    try testing.expectEqual(map.values.items.len, 2);
+    const directive = tree.getDirective(doc).?;
+    try testing.expectEqualStrings("tapi-tbd", directive);
 
+    const doc_value = tree.nodeData(doc).doc_with_directive.value;
+    try testing.expect(doc_value != .none);
+    try testing.expectEqual(.map, tree.nodeTag(doc_value.unwrap().?));
+
+    const map = doc_value.unwrap().?;
+    const map_scope = parser.nodes_scopes.get(map).?;
+    try testing.expectEqual(5, @intFromEnum(map_scope.start));
+    try testing.expectEqual(14, @intFromEnum(map_scope.end));
+
+    const map_data = tree.extraData(parse.Map, tree.nodeData(map).extra);
+    try testing.expectEqual(2, map_data.data.map_len);
+
+    var entry_data = tree.extraData(parse.Map.Entry, map_data.end);
     {
-        const entry = map.values.items[0];
-
-        const key = tree.getToken(entry.key);
+        const key = tree.getToken(entry_data.data.key);
         try testing.expectEqual(key.id, .literal);
-        try testing.expectEqualStrings("tbd-version", tree.source[key.loc.start..key.loc.end]);
+        try testing.expectEqualStrings("tbd-version", tree.getRaw(entry_data.data.key, entry_data.data.key));
 
-        const value = entry.value.?.cast(Node.Value).?;
-        const value_tok = tree.getToken(value.base.start);
-        try testing.expectEqual(value_tok.id, .literal);
-        try testing.expectEqualStrings("4", tree.source[value_tok.loc.start..value_tok.loc.end]);
+        const maybe_value = entry_data.data.value;
+        try testing.expect(maybe_value != .none);
+        try testing.expectEqual(.value, tree.nodeTag(maybe_value.unwrap().?));
+
+        const value = maybe_value.unwrap().?;
+        const string = tree.nodeData(value).string.slice(tree);
+        try testing.expectEqualStrings("4", string);
     }
 
+    entry_data = tree.extraData(parse.Map.Entry, entry_data.end);
     {
-        const entry = map.values.items[1];
-
-        const key = tree.getToken(entry.key);
+        const key = tree.getToken(entry_data.data.key);
         try testing.expectEqual(key.id, .literal);
-        try testing.expectEqualStrings("abc-version", tree.source[key.loc.start..key.loc.end]);
+        try testing.expectEqualStrings("abc-version", tree.getRaw(entry_data.data.key, entry_data.data.key));
 
-        const value = entry.value.?.cast(Node.Value).?;
-        const value_tok = tree.getToken(value.base.start);
-        try testing.expectEqual(value_tok.id, .literal);
-        try testing.expectEqualStrings("5", tree.source[value_tok.loc.start..value_tok.loc.end]);
+        const maybe_value = entry_data.data.value;
+        try testing.expect(maybe_value != .none);
+        try testing.expectEqual(.value, tree.nodeTag(maybe_value.unwrap().?));
+
+        const value = maybe_value.unwrap().?;
+        const string = tree.nodeData(value).string.slice(tree);
+        try testing.expectEqualStrings("5", string);
     }
 }
 
-test "leaf in quotes" {
-    const source =
-        \\key1: no quotes, comma
-        \\key2: 'single quoted'
-        \\key3: "double quoted"
-    ;
-
-    var tree = Tree.init(testing.allocator);
-    defer tree.deinit();
-    try tree.parse(source);
-
-    try testing.expectEqual(tree.docs.items.len, 1);
-
-    const doc = tree.docs.items[0].cast(Node.Doc).?;
-    try testing.expectEqual(@intFromEnum(doc.base.start), 0);
-    try testing.expectEqual(@intFromEnum(doc.base.end), tree.tokens.len - 2);
-    try testing.expect(doc.directive == null);
-
-    try testing.expect(doc.value != null);
-    try testing.expectEqual(doc.value.?.tag, .map);
-
-    const map = doc.value.?.cast(Node.Map).?;
-    try testing.expectEqual(@intFromEnum(map.base.start), 0);
-    try testing.expectEqual(@intFromEnum(map.base.end), tree.tokens.len - 2);
-    try testing.expectEqual(map.values.items.len, 3);
-
-    {
-        const entry = map.values.items[0];
-
-        const key = tree.getToken(entry.key);
-        try testing.expectEqual(key.id, .literal);
-        try testing.expectEqualStrings("key1", tree.source[key.loc.start..key.loc.end]);
-
-        const value = entry.value.?.cast(Node.Value).?;
-        const start = tree.getToken(value.base.start);
-        const end = tree.getToken(value.base.end);
-        try testing.expectEqual(start.id, .literal);
-        try testing.expectEqual(end.id, .literal);
-        try testing.expectEqualStrings("no quotes, comma", tree.source[start.loc.start..end.loc.end]);
-    }
-}
-
-test "nested maps" {
-    const source =
-        \\key1:
-        \\  key1_1 : value1_1
-        \\  key1_2 : value1_2
-        \\key2   : value2
-    ;
-
-    var tree = Tree.init(testing.allocator);
-    defer tree.deinit();
-    try tree.parse(source);
-
-    try testing.expectEqual(tree.docs.items.len, 1);
-
-    const doc = tree.docs.items[0].cast(Node.Doc).?;
-    try testing.expectEqual(@intFromEnum(doc.base.start), 0);
-    try testing.expectEqual(@intFromEnum(doc.base.end), tree.tokens.len - 2);
-    try testing.expect(doc.directive == null);
-
-    try testing.expect(doc.value != null);
-    try testing.expectEqual(doc.value.?.tag, .map);
-
-    const map = doc.value.?.cast(Node.Map).?;
-    try testing.expectEqual(@intFromEnum(map.base.start), 0);
-    try testing.expectEqual(@intFromEnum(map.base.end), tree.tokens.len - 2);
-    try testing.expectEqual(map.values.items.len, 2);
-
-    {
-        const entry = map.values.items[0];
-
-        const key = tree.getToken(entry.key);
-        try testing.expectEqual(key.id, .literal);
-        try testing.expectEqualStrings("key1", tree.source[key.loc.start..key.loc.end]);
-
-        const nested_map = entry.value.?.cast(Node.Map).?;
-        try testing.expectEqual(@intFromEnum(nested_map.base.start), 4);
-        try testing.expectEqual(@intFromEnum(nested_map.base.end), 16);
-        try testing.expectEqual(nested_map.values.items.len, 2);
-
-        {
-            const nested_entry = nested_map.values.items[0];
-
-            const nested_key = tree.getToken(nested_entry.key);
-            try testing.expectEqual(nested_key.id, .literal);
-            try testing.expectEqualStrings("key1_1", tree.source[nested_key.loc.start..nested_key.loc.end]);
-
-            const nested_value = nested_entry.value.?.cast(Node.Value).?;
-            const nested_value_tok = tree.getToken(nested_value.base.start);
-            try testing.expectEqual(nested_value_tok.id, .literal);
-            try testing.expectEqualStrings(
-                "value1_1",
-                tree.source[nested_value_tok.loc.start..nested_value_tok.loc.end],
-            );
-        }
-
-        {
-            const nested_entry = nested_map.values.items[1];
-
-            const nested_key = tree.getToken(nested_entry.key);
-            try testing.expectEqual(nested_key.id, .literal);
-            try testing.expectEqualStrings("key1_2", tree.source[nested_key.loc.start..nested_key.loc.end]);
-
-            const nested_value = nested_entry.value.?.cast(Node.Value).?;
-            const nested_value_tok = tree.getToken(nested_value.base.start);
-            try testing.expectEqual(nested_value_tok.id, .literal);
-            try testing.expectEqualStrings(
-                "value1_2",
-                tree.source[nested_value_tok.loc.start..nested_value_tok.loc.end],
-            );
-        }
-    }
-
-    {
-        const entry = map.values.items[1];
-
-        const key = tree.getToken(entry.key);
-        try testing.expectEqual(key.id, .literal);
-        try testing.expectEqualStrings("key2", tree.source[key.loc.start..key.loc.end]);
-
-        const value = entry.value.?.cast(Node.Value).?;
-        const value_tok = tree.getToken(value.base.start);
-        try testing.expectEqual(value_tok.id, .literal);
-        try testing.expectEqualStrings("value2", tree.source[value_tok.loc.start..value_tok.loc.end]);
-    }
-}
-
-test "map of list of values" {
-    const source =
-        \\ints:
-        \\  - 0
-        \\  - 1
-        \\  - 2
-    ;
-    var tree = Tree.init(testing.allocator);
-    defer tree.deinit();
-    try tree.parse(source);
-
-    try testing.expectEqual(tree.docs.items.len, 1);
-
-    const doc = tree.docs.items[0].cast(Node.Doc).?;
-    try testing.expectEqual(@intFromEnum(doc.base.start), 0);
-    try testing.expectEqual(@intFromEnum(doc.base.end), tree.tokens.len - 2);
-
-    try testing.expect(doc.value != null);
-    try testing.expectEqual(doc.value.?.tag, .map);
-
-    const map = doc.value.?.cast(Node.Map).?;
-    try testing.expectEqual(@intFromEnum(map.base.start), 0);
-    try testing.expectEqual(@intFromEnum(map.base.end), tree.tokens.len - 2);
-    try testing.expectEqual(map.values.items.len, 1);
-
-    const entry = map.values.items[0];
-    const key = tree.getToken(entry.key);
-    try testing.expectEqual(key.id, .literal);
-    try testing.expectEqualStrings("ints", tree.source[key.loc.start..key.loc.end]);
-
-    const value = entry.value.?.cast(Node.List).?;
-    try testing.expectEqual(@intFromEnum(value.base.start), 4);
-    try testing.expectEqual(@intFromEnum(value.base.end), tree.tokens.len - 2);
-    try testing.expectEqual(value.values.items.len, 3);
-
-    {
-        const elem = value.values.items[0].cast(Node.Value).?;
-        const leaf = tree.getToken(elem.base.start);
-        try testing.expectEqual(leaf.id, .literal);
-        try testing.expectEqualStrings("0", tree.source[leaf.loc.start..leaf.loc.end]);
-    }
-
-    {
-        const elem = value.values.items[1].cast(Node.Value).?;
-        const leaf = tree.getToken(elem.base.start);
-        try testing.expectEqual(leaf.id, .literal);
-        try testing.expectEqualStrings("1", tree.source[leaf.loc.start..leaf.loc.end]);
-    }
-
-    {
-        const elem = value.values.items[2].cast(Node.Value).?;
-        const leaf = tree.getToken(elem.base.start);
-        try testing.expectEqual(leaf.id, .literal);
-        try testing.expectEqualStrings("2", tree.source[leaf.loc.start..leaf.loc.end]);
-    }
-}
-
-test "map of list of maps" {
-    const source =
-        \\key1:
-        \\- key2 : value2
-        \\- key3 : value3
-        \\- key4 : value4
-    ;
-
-    var tree = Tree.init(testing.allocator);
-    defer tree.deinit();
-    try tree.parse(source);
-
-    try testing.expectEqual(tree.docs.items.len, 1);
-
-    const doc = tree.docs.items[0].cast(Node.Doc).?;
-    try testing.expectEqual(@intFromEnum(doc.base.start), 0);
-    try testing.expectEqual(@intFromEnum(doc.base.end), tree.tokens.len - 2);
-
-    try testing.expect(doc.value != null);
-    try testing.expectEqual(doc.value.?.tag, .map);
-
-    const map = doc.value.?.cast(Node.Map).?;
-    try testing.expectEqual(@intFromEnum(map.base.start), 0);
-    try testing.expectEqual(@intFromEnum(map.base.end), tree.tokens.len - 2);
-    try testing.expectEqual(map.values.items.len, 1);
-
-    const entry = map.values.items[0];
-    const key = tree.getToken(entry.key);
-    try testing.expectEqual(key.id, .literal);
-    try testing.expectEqualStrings("key1", tree.source[key.loc.start..key.loc.end]);
-
-    const value = entry.value.?.cast(Node.List).?;
-    try testing.expectEqual(@intFromEnum(value.base.start), 3);
-    try testing.expectEqual(@intFromEnum(value.base.end), tree.tokens.len - 2);
-    try testing.expectEqual(value.values.items.len, 3);
-
-    {
-        const elem = value.values.items[0].cast(Node.Map).?;
-        const nested = elem.values.items[0];
-        const nested_key = tree.getToken(nested.key);
-        try testing.expectEqual(nested_key.id, .literal);
-        try testing.expectEqualStrings("key2", tree.source[nested_key.loc.start..nested_key.loc.end]);
-
-        const nested_v = nested.value.?.cast(Node.Value).?;
-        const leaf = tree.getToken(nested_v.base.start);
-        try testing.expectEqual(leaf.id, .literal);
-        try testing.expectEqualStrings("value2", tree.source[leaf.loc.start..leaf.loc.end]);
-    }
-
-    {
-        const elem = value.values.items[1].cast(Node.Map).?;
-        const nested = elem.values.items[0];
-        const nested_key = tree.getToken(nested.key);
-        try testing.expectEqual(nested_key.id, .literal);
-        try testing.expectEqualStrings("key3", tree.source[nested_key.loc.start..nested_key.loc.end]);
-
-        const nested_v = nested.value.?.cast(Node.Value).?;
-        const leaf = tree.getToken(nested_v.base.start);
-        try testing.expectEqual(leaf.id, .literal);
-        try testing.expectEqualStrings("value3", tree.source[leaf.loc.start..leaf.loc.end]);
-    }
-
-    {
-        const elem = value.values.items[2].cast(Node.Map).?;
-        const nested = elem.values.items[0];
-        const nested_key = tree.getToken(nested.key);
-        try testing.expectEqual(nested_key.id, .literal);
-        try testing.expectEqualStrings("key4", tree.source[nested_key.loc.start..nested_key.loc.end]);
-
-        const nested_v = nested.value.?.cast(Node.Value).?;
-        const leaf = tree.getToken(nested_v.base.start);
-        try testing.expectEqual(leaf.id, .literal);
-        try testing.expectEqualStrings("value4", tree.source[leaf.loc.start..leaf.loc.end]);
-    }
-}
-
-test "map of list of maps with inner list" {
-    const source =
-        \\ outer:
-        \\   - a: foo
-        \\     fooers:
-        \\       - name: inner-foo
-        \\   - b: bar
-        \\     fooers:
-        \\       - name: inner-bar
-    ;
-
-    var tree = Tree.init(testing.allocator);
-    defer tree.deinit();
-    try tree.parse(source);
-
-    try testing.expectEqual(tree.docs.items.len, 1);
-
-    const doc = tree.docs.items[0].cast(Node.Doc).?;
-    try testing.expectEqual(@intFromEnum(doc.base.start), 1);
-    try testing.expectEqual(@intFromEnum(doc.base.end), tree.tokens.len - 2);
-
-    try testing.expect(doc.value != null);
-    try testing.expectEqual(doc.value.?.tag, .map);
-
-    const map = doc.value.?.cast(Node.Map).?;
-    try testing.expectEqual(@intFromEnum(map.base.start), 1);
-    try testing.expectEqual(@intFromEnum(map.base.end), tree.tokens.len - 2);
-    try testing.expectEqual(map.values.items.len, 1);
-
-    const entry = map.values.items[0];
-    const key = tree.getToken(entry.key);
-    try testing.expectEqual(key.id, .literal);
-    try testing.expectEqualStrings("outer", tree.source[key.loc.start..key.loc.end]);
-
-    const value = entry.value.?.cast(Node.List).?;
-    try testing.expectEqual(@intFromEnum(value.base.start), 5);
-    try testing.expectEqual(@intFromEnum(value.base.end), tree.tokens.len - 2);
-    try testing.expectEqual(value.values.items.len, 2);
-
-    {
-        const elem = value.values.items[0].cast(Node.Map).?;
-        const nested = elem.values.items[0];
-        const nested_key = tree.getToken(nested.key);
-        try testing.expectEqual(nested_key.id, .literal);
-        try testing.expectEqualStrings("a", tree.source[nested_key.loc.start..nested_key.loc.end]);
-
-        const nested_v = nested.value.?.cast(Node.Value).?;
-        const leaf = tree.getToken(nested_v.base.start);
-        try testing.expectEqual(leaf.id, .literal);
-        try testing.expectEqualStrings("foo", tree.source[leaf.loc.start..leaf.loc.end]);
-
-        {
-            const elem_with_inner_list = elem.values.items[1];
-            const elem_with_inner_list_key = tree.getToken(elem_with_inner_list.key);
-            try testing.expectEqual(elem_with_inner_list_key.id, .literal);
-            try testing.expectEqualStrings("fooers", tree.source[elem_with_inner_list_key.loc.start..elem_with_inner_list_key.loc.end]);
-
-            const elem_with_inner_list_value = elem_with_inner_list.value.?.cast(Node.List).?;
-            try testing.expectEqual(elem_with_inner_list_value.values.items.len, 1);
-
-            const innermost_entries = elem_with_inner_list_value.values.items[0].cast(Node.Map).?;
-            const innermost_elem = innermost_entries.values.items[0];
-            const innermost_key = tree.getToken(innermost_elem.key);
-            try testing.expectEqual(innermost_key.id, .literal);
-            try testing.expectEqualStrings("name", tree.source[innermost_key.loc.start..innermost_key.loc.end]);
-
-            const innermost_value = innermost_elem.value.?.cast(Node.Value).?;
-            const innermost_leaf = tree.getToken(innermost_value.base.start);
-            try testing.expectEqual(innermost_leaf.id, .literal);
-            try testing.expectEqualStrings("inner-foo", tree.source[innermost_leaf.loc.start..innermost_leaf.loc.end]);
-        }
-    }
-
-    {
-        const elem = value.values.items[1].cast(Node.Map).?;
-        const nested = elem.values.items[0];
-        const nested_key = tree.getToken(nested.key);
-        try testing.expectEqual(nested_key.id, .literal);
-        try testing.expectEqualStrings("b", tree.source[nested_key.loc.start..nested_key.loc.end]);
-
-        const nested_v = nested.value.?.cast(Node.Value).?;
-        const leaf = tree.getToken(nested_v.base.start);
-        try testing.expectEqual(leaf.id, .literal);
-        try testing.expectEqualStrings("bar", tree.source[leaf.loc.start..leaf.loc.end]);
-
-        {
-            const elem_with_inner_list = elem.values.items[1];
-            const elem_with_inner_list_key = tree.getToken(elem_with_inner_list.key);
-            try testing.expectEqual(elem_with_inner_list_key.id, .literal);
-            try testing.expectEqualStrings("fooers", tree.source[elem_with_inner_list_key.loc.start..elem_with_inner_list_key.loc.end]);
-
-            const elem_with_inner_list_value = elem_with_inner_list.value.?.cast(Node.List).?;
-            try testing.expectEqual(elem_with_inner_list_value.values.items.len, 1);
-
-            const innermost_entries = elem_with_inner_list_value.values.items[0].cast(Node.Map).?;
-            const innermost_elem = innermost_entries.values.items[0];
-            const innermost_key = tree.getToken(innermost_elem.key);
-            try testing.expectEqual(innermost_key.id, .literal);
-            try testing.expectEqualStrings("name", tree.source[innermost_key.loc.start..innermost_key.loc.end]);
-
-            const innermost_value = innermost_elem.value.?.cast(Node.Value).?;
-            const innermost_leaf = tree.getToken(innermost_value.base.start);
-            try testing.expectEqual(innermost_leaf.id, .literal);
-            try testing.expectEqualStrings("inner-bar", tree.source[innermost_leaf.loc.start..innermost_leaf.loc.end]);
-        }
-    }
-}
-
-test "list of lists" {
-    const source =
-        \\- [name        , hr, avg  ]
-        \\- [Mark McGwire , 65, 0.278]
-        \\- [Sammy Sosa   , 63, 0.288]
-    ;
-
-    var tree = Tree.init(testing.allocator);
-    defer tree.deinit();
-    try tree.parse(source);
-
-    try testing.expectEqual(tree.docs.items.len, 1);
-
-    const doc = tree.docs.items[0].cast(Node.Doc).?;
-    try testing.expectEqual(@intFromEnum(doc.base.start), 0);
-    try testing.expectEqual(@intFromEnum(doc.base.end), tree.tokens.len - 2);
-
-    try testing.expect(doc.value != null);
-    try testing.expectEqual(doc.value.?.tag, .list);
-
-    const list = doc.value.?.cast(Node.List).?;
-    try testing.expectEqual(@intFromEnum(list.base.start), 0);
-    try testing.expectEqual(@intFromEnum(list.base.end), tree.tokens.len - 2);
-    try testing.expectEqual(list.values.items.len, 3);
-
-    {
-        try testing.expectEqual(list.values.items[0].tag, .list);
-        const nested = list.values.items[0].cast(Node.List).?;
-        try testing.expectEqual(nested.values.items.len, 3);
-
-        {
-            try testing.expectEqual(nested.values.items[0].tag, .value);
-            const value = nested.values.items[0].cast(Node.Value).?;
-            const leaf = tree.getToken(value.base.start);
-            try testing.expectEqualStrings("name", tree.source[leaf.loc.start..leaf.loc.end]);
-        }
-
-        {
-            try testing.expectEqual(nested.values.items[1].tag, .value);
-            const value = nested.values.items[1].cast(Node.Value).?;
-            const leaf = tree.getToken(value.base.start);
-            try testing.expectEqualStrings("hr", tree.source[leaf.loc.start..leaf.loc.end]);
-        }
-
-        {
-            try testing.expectEqual(nested.values.items[2].tag, .value);
-            const value = nested.values.items[2].cast(Node.Value).?;
-            const leaf = tree.getToken(value.base.start);
-            try testing.expectEqualStrings("avg", tree.source[leaf.loc.start..leaf.loc.end]);
-        }
-    }
-
-    {
-        try testing.expectEqual(list.values.items[1].tag, .list);
-        const nested = list.values.items[1].cast(Node.List).?;
-        try testing.expectEqual(nested.values.items.len, 3);
-
-        {
-            try testing.expectEqual(nested.values.items[0].tag, .value);
-            const value = nested.values.items[0].cast(Node.Value).?;
-            const start = tree.getToken(value.base.start);
-            const end = tree.getToken(value.base.end);
-            try testing.expectEqualStrings("Mark McGwire", tree.source[start.loc.start..end.loc.end]);
-        }
-
-        {
-            try testing.expectEqual(nested.values.items[1].tag, .value);
-            const value = nested.values.items[1].cast(Node.Value).?;
-            const leaf = tree.getToken(value.base.start);
-            try testing.expectEqualStrings("65", tree.source[leaf.loc.start..leaf.loc.end]);
-        }
-
-        {
-            try testing.expectEqual(nested.values.items[2].tag, .value);
-            const value = nested.values.items[2].cast(Node.Value).?;
-            const leaf = tree.getToken(value.base.start);
-            try testing.expectEqualStrings("0.278", tree.source[leaf.loc.start..leaf.loc.end]);
-        }
-    }
-
-    {
-        try testing.expectEqual(list.values.items[2].tag, .list);
-        const nested = list.values.items[2].cast(Node.List).?;
-        try testing.expectEqual(nested.values.items.len, 3);
-
-        {
-            try testing.expectEqual(nested.values.items[0].tag, .value);
-            const value = nested.values.items[0].cast(Node.Value).?;
-            const start = tree.getToken(value.base.start);
-            const end = tree.getToken(value.base.end);
-            try testing.expectEqualStrings("Sammy Sosa", tree.source[start.loc.start..end.loc.end]);
-        }
-
-        {
-            try testing.expectEqual(nested.values.items[1].tag, .value);
-            const value = nested.values.items[1].cast(Node.Value).?;
-            const leaf = tree.getToken(value.base.start);
-            try testing.expectEqualStrings("63", tree.source[leaf.loc.start..leaf.loc.end]);
-        }
-
-        {
-            try testing.expectEqual(nested.values.items[2].tag, .value);
-            const value = nested.values.items[2].cast(Node.Value).?;
-            const leaf = tree.getToken(value.base.start);
-            try testing.expectEqualStrings("0.288", tree.source[leaf.loc.start..leaf.loc.end]);
-        }
-    }
-}
-
-test "inline list" {
-    const source =
-        \\[name        , hr, avg  ]
-    ;
-
-    var tree = Tree.init(testing.allocator);
-    defer tree.deinit();
-    try tree.parse(source);
-
-    try testing.expectEqual(tree.docs.items.len, 1);
-
-    const doc = tree.docs.items[0].cast(Node.Doc).?;
-    try testing.expectEqual(@intFromEnum(doc.base.start), 0);
-    try testing.expectEqual(@intFromEnum(doc.base.end), tree.tokens.len - 2);
-
-    try testing.expect(doc.value != null);
-    try testing.expectEqual(doc.value.?.tag, .list);
-
-    const list = doc.value.?.cast(Node.List).?;
-    try testing.expectEqual(@intFromEnum(list.base.start), 0);
-    try testing.expectEqual(@intFromEnum(list.base.end), tree.tokens.len - 2);
-    try testing.expectEqual(list.values.items.len, 3);
-
-    {
-        try testing.expectEqual(list.values.items[0].tag, .value);
-        const value = list.values.items[0].cast(Node.Value).?;
-        const leaf = tree.getToken(value.base.start);
-        try testing.expectEqualStrings("name", tree.source[leaf.loc.start..leaf.loc.end]);
-    }
-
-    {
-        try testing.expectEqual(list.values.items[1].tag, .value);
-        const value = list.values.items[1].cast(Node.Value).?;
-        const leaf = tree.getToken(value.base.start);
-        try testing.expectEqualStrings("hr", tree.source[leaf.loc.start..leaf.loc.end]);
-    }
-
-    {
-        try testing.expectEqual(list.values.items[2].tag, .value);
-        const value = list.values.items[2].cast(Node.Value).?;
-        const leaf = tree.getToken(value.base.start);
-        try testing.expectEqualStrings("avg", tree.source[leaf.loc.start..leaf.loc.end]);
-    }
-}
-
-test "inline list as mapping value" {
-    const source =
-        \\key : [
-        \\        name        ,
-        \\        hr, avg  ]
-    ;
-
-    var tree = Tree.init(testing.allocator);
-    defer tree.deinit();
-    try tree.parse(source);
-
-    try testing.expectEqual(tree.docs.items.len, 1);
-
-    const doc = tree.docs.items[0].cast(Node.Doc).?;
-    try testing.expectEqual(@intFromEnum(doc.base.start), 0);
-    try testing.expectEqual(@intFromEnum(doc.base.end), tree.tokens.len - 2);
-
-    try testing.expect(doc.value != null);
-    try testing.expectEqual(doc.value.?.tag, .map);
-
-    const map = doc.value.?.cast(Node.Map).?;
-    try testing.expectEqual(@intFromEnum(map.base.start), 0);
-    try testing.expectEqual(@intFromEnum(map.base.end), tree.tokens.len - 2);
-    try testing.expectEqual(map.values.items.len, 1);
-
-    const entry = map.values.items[0];
-    const key = tree.getToken(entry.key);
-    try testing.expectEqual(key.id, .literal);
-    try testing.expectEqualStrings("key", tree.source[key.loc.start..key.loc.end]);
-
-    const list = entry.value.?.cast(Node.List).?;
-    try testing.expectEqual(@intFromEnum(list.base.start), 4);
-    try testing.expectEqual(@intFromEnum(list.base.end), tree.tokens.len - 2);
-    try testing.expectEqual(list.values.items.len, 3);
-
-    {
-        try testing.expectEqual(list.values.items[0].tag, .value);
-        const value = list.values.items[0].cast(Node.Value).?;
-        const leaf = tree.getToken(value.base.start);
-        try testing.expectEqualStrings("name", tree.source[leaf.loc.start..leaf.loc.end]);
-    }
-
-    {
-        try testing.expectEqual(list.values.items[1].tag, .value);
-        const value = list.values.items[1].cast(Node.Value).?;
-        const leaf = tree.getToken(value.base.start);
-        try testing.expectEqualStrings("hr", tree.source[leaf.loc.start..leaf.loc.end]);
-    }
-
-    {
-        try testing.expectEqual(list.values.items[2].tag, .value);
-        const value = list.values.items[2].cast(Node.Value).?;
-        const leaf = tree.getToken(value.base.start);
-        try testing.expectEqualStrings("avg", tree.source[leaf.loc.start..leaf.loc.end]);
-    }
-}
-
-fn parseSuccess(comptime source: []const u8) !void {
-    var tree = Tree.init(testing.allocator);
-    defer tree.deinit();
-    try tree.parse(source);
-}
-
-fn parseError(comptime source: []const u8, err: parse.ParseError) !void {
-    var tree = Tree.init(testing.allocator);
-    defer tree.deinit();
-    try testing.expectError(err, tree.parse(source));
-}
-
-test "empty doc with spaces and comments" {
-    try parseSuccess(
-        \\
-        \\
-        \\   # this is a comment in a weird place
-        \\# and this one is too
-    );
-}
-
-test "comment between --- and ! in document start" {
-    try parseError(
-        \\--- # what is it?
-        \\!
-    , error.UnexpectedToken);
-}
-
-test "correct doc start with tag" {
-    try parseSuccess(
-        \\--- !some-tag
-        \\
-    );
-}
-
-test "doc close without explicit doc open" {
-    try parseError(
-        \\
-        \\
-        \\# something cool
-        \\...
-    , error.UnexpectedToken);
-}
-
-test "doc open and close are ok" {
-    try parseSuccess(
-        \\---
-        \\# first doc
-        \\
-        \\
-        \\---
-        \\# second doc
-        \\
-        \\
-        \\...
-    );
-}
-
-test "doc with a single string is ok" {
-    try parseSuccess(
-        \\a string of some sort
-        \\
-    );
-}
-
-test "explicit doc with a single string is ok" {
-    try parseSuccess(
-        \\--- !anchor
-        \\# nothing to see here except one string
-        \\  # not a lot to go on with
-        \\a single string
-        \\...
-    );
-}
-
-test "doc with two string is bad" {
-    try parseError(
-        \\first
-        \\second
-        \\# this should fail already
-    , error.UnexpectedToken);
-}
-
-test "single quote string can have new lines" {
-    try parseSuccess(
-        \\'what is this
-        \\ thing?'
-    );
-}
-
-test "single quote string on one line is fine" {
-    try parseSuccess(
-        \\'here''s an apostrophe'
-    );
-}
-
-test "double quote string can have new lines" {
-    try parseSuccess(
-        \\"what is this
-        \\ thing?"
-    );
-}
-
-test "double quote string on one line is fine" {
-    try parseSuccess(
-        \\"a newline\nand a\ttab"
-    );
-}
-
-test "map with key and value literals" {
-    try parseSuccess(
-        \\key1: val1
-        \\key2 : val2
-    );
-}
-
-test "map of maps" {
-    try parseSuccess(
-        \\
-        \\# the first key
-        \\key1:
-        \\  # the first subkey
-        \\  key1_1: 0
-        \\  key1_2: 1
-        \\# the second key
-        \\key2:
-        \\  key2_1: -1
-        \\  key2_2: -2
-        \\# the end of map
-    );
-}
-
-test "map value indicator needs to be on the same line" {
-    try parseError(
-        \\a
-        \\  : b
-    , error.UnexpectedToken);
-}
-
-test "value needs to be indented" {
-    try parseError(
-        \\a:
-        \\b
-    , error.MalformedYaml);
-}
-
-test "comment between a key and a value is fine" {
-    try parseSuccess(
-        \\a:
-        \\  # this is a value
-        \\  b
-    );
-}
-
-test "simple list" {
-    try parseSuccess(
-        \\# first el
-        \\- a
-        \\# second el
-        \\-  b
-        \\# third el
-        \\-   c
-    );
-}
-
-test "list indentation matters" {
-    try parseError(
-        \\  - a
-        \\- b
-    , error.UnexpectedToken);
-
-    try parseSuccess(
-        \\- a
-        \\  - b
-    );
-}
-
-test "unindented list is fine too" {
-    try parseSuccess(
-        \\a:
-        \\- 0
-        \\- 1
-    );
-}
-
-test "empty values in a map" {
-    try parseSuccess(
-        \\a:
-        \\b:
-        \\- 0
-    );
-}
-
-test "weirdly nested map of maps of lists" {
-    try parseSuccess(
-        \\a:
-        \\ b:
-        \\  - 0
-        \\  - 1
-    );
-}
-
-test "square brackets denote a list" {
-    try parseSuccess(
-        \\[ a,
-        \\  b, c ]
-    );
-}
-
-test "empty list" {
-    try parseSuccess(
-        \\[ ]
-    );
-}
-
-test "empty map" {
-    try parseSuccess(
-        \\a:
-        \\  b: {}
-        \\  c: { }
-    );
-}
-
-test "comment within a bracketed list is an error" {
-    try parseError(
-        \\[ # something
-        \\]
-    , error.MalformedYaml);
-}
-
-test "mixed ints with floats in a list" {
-    try parseSuccess(
-        \\[0, 1.0]
-    );
-}
+// test "leaf in quotes" {
+//     const source =
+//         \\key1: no quotes, comma
+//         \\key2: 'single quoted'
+//         \\key3: "double quoted"
+//     ;
+
+//     var tree = Tree.init(testing.allocator);
+//     defer tree.deinit();
+//     try tree.parse(source);
+
+//     try testing.expectEqual(tree.docs.items.len, 1);
+
+//     const doc = tree.docs.items[0].cast(Node.Doc).?;
+//     try testing.expectEqual(@intFromEnum(doc.base.start), 0);
+//     try testing.expectEqual(@intFromEnum(doc.base.end), tree.tokens.len - 2);
+//     try testing.expect(doc.directive == null);
+
+//     try testing.expect(doc.value != null);
+//     try testing.expectEqual(doc.value.?.tag, .map);
+
+//     const map = doc.value.?.cast(Node.Map).?;
+//     try testing.expectEqual(@intFromEnum(map.base.start), 0);
+//     try testing.expectEqual(@intFromEnum(map.base.end), tree.tokens.len - 2);
+//     try testing.expectEqual(map.values.items.len, 3);
+
+//     {
+//         const entry = map.values.items[0];
+
+//         const key = tree.getToken(entry.key);
+//         try testing.expectEqual(key.id, .literal);
+//         try testing.expectEqualStrings("key1", tree.source[key.loc.start..key.loc.end]);
+
+//         const value = entry.value.?.cast(Node.Value).?;
+//         const start = tree.getToken(value.base.start);
+//         const end = tree.getToken(value.base.end);
+//         try testing.expectEqual(start.id, .literal);
+//         try testing.expectEqual(end.id, .literal);
+//         try testing.expectEqualStrings("no quotes, comma", tree.source[start.loc.start..end.loc.end]);
+//     }
+// }
+
+// test "nested maps" {
+//     const source =
+//         \\key1:
+//         \\  key1_1 : value1_1
+//         \\  key1_2 : value1_2
+//         \\key2   : value2
+//     ;
+
+//     var tree = Tree.init(testing.allocator);
+//     defer tree.deinit();
+//     try tree.parse(source);
+
+//     try testing.expectEqual(tree.docs.items.len, 1);
+
+//     const doc = tree.docs.items[0].cast(Node.Doc).?;
+//     try testing.expectEqual(@intFromEnum(doc.base.start), 0);
+//     try testing.expectEqual(@intFromEnum(doc.base.end), tree.tokens.len - 2);
+//     try testing.expect(doc.directive == null);
+
+//     try testing.expect(doc.value != null);
+//     try testing.expectEqual(doc.value.?.tag, .map);
+
+//     const map = doc.value.?.cast(Node.Map).?;
+//     try testing.expectEqual(@intFromEnum(map.base.start), 0);
+//     try testing.expectEqual(@intFromEnum(map.base.end), tree.tokens.len - 2);
+//     try testing.expectEqual(map.values.items.len, 2);
+
+//     {
+//         const entry = map.values.items[0];
+
+//         const key = tree.getToken(entry.key);
+//         try testing.expectEqual(key.id, .literal);
+//         try testing.expectEqualStrings("key1", tree.source[key.loc.start..key.loc.end]);
+
+//         const nested_map = entry.value.?.cast(Node.Map).?;
+//         try testing.expectEqual(@intFromEnum(nested_map.base.start), 4);
+//         try testing.expectEqual(@intFromEnum(nested_map.base.end), 16);
+//         try testing.expectEqual(nested_map.values.items.len, 2);
+
+//         {
+//             const nested_entry = nested_map.values.items[0];
+
+//             const nested_key = tree.getToken(nested_entry.key);
+//             try testing.expectEqual(nested_key.id, .literal);
+//             try testing.expectEqualStrings("key1_1", tree.source[nested_key.loc.start..nested_key.loc.end]);
+
+//             const nested_value = nested_entry.value.?.cast(Node.Value).?;
+//             const nested_value_tok = tree.getToken(nested_value.base.start);
+//             try testing.expectEqual(nested_value_tok.id, .literal);
+//             try testing.expectEqualStrings(
+//                 "value1_1",
+//                 tree.source[nested_value_tok.loc.start..nested_value_tok.loc.end],
+//             );
+//         }
+
+//         {
+//             const nested_entry = nested_map.values.items[1];
+
+//             const nested_key = tree.getToken(nested_entry.key);
+//             try testing.expectEqual(nested_key.id, .literal);
+//             try testing.expectEqualStrings("key1_2", tree.source[nested_key.loc.start..nested_key.loc.end]);
+
+//             const nested_value = nested_entry.value.?.cast(Node.Value).?;
+//             const nested_value_tok = tree.getToken(nested_value.base.start);
+//             try testing.expectEqual(nested_value_tok.id, .literal);
+//             try testing.expectEqualStrings(
+//                 "value1_2",
+//                 tree.source[nested_value_tok.loc.start..nested_value_tok.loc.end],
+//             );
+//         }
+//     }
+
+//     {
+//         const entry = map.values.items[1];
+
+//         const key = tree.getToken(entry.key);
+//         try testing.expectEqual(key.id, .literal);
+//         try testing.expectEqualStrings("key2", tree.source[key.loc.start..key.loc.end]);
+
+//         const value = entry.value.?.cast(Node.Value).?;
+//         const value_tok = tree.getToken(value.base.start);
+//         try testing.expectEqual(value_tok.id, .literal);
+//         try testing.expectEqualStrings("value2", tree.source[value_tok.loc.start..value_tok.loc.end]);
+//     }
+// }
+
+// test "map of list of values" {
+//     const source =
+//         \\ints:
+//         \\  - 0
+//         \\  - 1
+//         \\  - 2
+//     ;
+//     var tree = Tree.init(testing.allocator);
+//     defer tree.deinit();
+//     try tree.parse(source);
+
+//     try testing.expectEqual(tree.docs.items.len, 1);
+
+//     const doc = tree.docs.items[0].cast(Node.Doc).?;
+//     try testing.expectEqual(@intFromEnum(doc.base.start), 0);
+//     try testing.expectEqual(@intFromEnum(doc.base.end), tree.tokens.len - 2);
+
+//     try testing.expect(doc.value != null);
+//     try testing.expectEqual(doc.value.?.tag, .map);
+
+//     const map = doc.value.?.cast(Node.Map).?;
+//     try testing.expectEqual(@intFromEnum(map.base.start), 0);
+//     try testing.expectEqual(@intFromEnum(map.base.end), tree.tokens.len - 2);
+//     try testing.expectEqual(map.values.items.len, 1);
+
+//     const entry = map.values.items[0];
+//     const key = tree.getToken(entry.key);
+//     try testing.expectEqual(key.id, .literal);
+//     try testing.expectEqualStrings("ints", tree.source[key.loc.start..key.loc.end]);
+
+//     const value = entry.value.?.cast(Node.List).?;
+//     try testing.expectEqual(@intFromEnum(value.base.start), 4);
+//     try testing.expectEqual(@intFromEnum(value.base.end), tree.tokens.len - 2);
+//     try testing.expectEqual(value.values.items.len, 3);
+
+//     {
+//         const elem = value.values.items[0].cast(Node.Value).?;
+//         const leaf = tree.getToken(elem.base.start);
+//         try testing.expectEqual(leaf.id, .literal);
+//         try testing.expectEqualStrings("0", tree.source[leaf.loc.start..leaf.loc.end]);
+//     }
+
+//     {
+//         const elem = value.values.items[1].cast(Node.Value).?;
+//         const leaf = tree.getToken(elem.base.start);
+//         try testing.expectEqual(leaf.id, .literal);
+//         try testing.expectEqualStrings("1", tree.source[leaf.loc.start..leaf.loc.end]);
+//     }
+
+//     {
+//         const elem = value.values.items[2].cast(Node.Value).?;
+//         const leaf = tree.getToken(elem.base.start);
+//         try testing.expectEqual(leaf.id, .literal);
+//         try testing.expectEqualStrings("2", tree.source[leaf.loc.start..leaf.loc.end]);
+//     }
+// }
+
+// test "map of list of maps" {
+//     const source =
+//         \\key1:
+//         \\- key2 : value2
+//         \\- key3 : value3
+//         \\- key4 : value4
+//     ;
+
+//     var tree = Tree.init(testing.allocator);
+//     defer tree.deinit();
+//     try tree.parse(source);
+
+//     try testing.expectEqual(tree.docs.items.len, 1);
+
+//     const doc = tree.docs.items[0].cast(Node.Doc).?;
+//     try testing.expectEqual(@intFromEnum(doc.base.start), 0);
+//     try testing.expectEqual(@intFromEnum(doc.base.end), tree.tokens.len - 2);
+
+//     try testing.expect(doc.value != null);
+//     try testing.expectEqual(doc.value.?.tag, .map);
+
+//     const map = doc.value.?.cast(Node.Map).?;
+//     try testing.expectEqual(@intFromEnum(map.base.start), 0);
+//     try testing.expectEqual(@intFromEnum(map.base.end), tree.tokens.len - 2);
+//     try testing.expectEqual(map.values.items.len, 1);
+
+//     const entry = map.values.items[0];
+//     const key = tree.getToken(entry.key);
+//     try testing.expectEqual(key.id, .literal);
+//     try testing.expectEqualStrings("key1", tree.source[key.loc.start..key.loc.end]);
+
+//     const value = entry.value.?.cast(Node.List).?;
+//     try testing.expectEqual(@intFromEnum(value.base.start), 3);
+//     try testing.expectEqual(@intFromEnum(value.base.end), tree.tokens.len - 2);
+//     try testing.expectEqual(value.values.items.len, 3);
+
+//     {
+//         const elem = value.values.items[0].cast(Node.Map).?;
+//         const nested = elem.values.items[0];
+//         const nested_key = tree.getToken(nested.key);
+//         try testing.expectEqual(nested_key.id, .literal);
+//         try testing.expectEqualStrings("key2", tree.source[nested_key.loc.start..nested_key.loc.end]);
+
+//         const nested_v = nested.value.?.cast(Node.Value).?;
+//         const leaf = tree.getToken(nested_v.base.start);
+//         try testing.expectEqual(leaf.id, .literal);
+//         try testing.expectEqualStrings("value2", tree.source[leaf.loc.start..leaf.loc.end]);
+//     }
+
+//     {
+//         const elem = value.values.items[1].cast(Node.Map).?;
+//         const nested = elem.values.items[0];
+//         const nested_key = tree.getToken(nested.key);
+//         try testing.expectEqual(nested_key.id, .literal);
+//         try testing.expectEqualStrings("key3", tree.source[nested_key.loc.start..nested_key.loc.end]);
+
+//         const nested_v = nested.value.?.cast(Node.Value).?;
+//         const leaf = tree.getToken(nested_v.base.start);
+//         try testing.expectEqual(leaf.id, .literal);
+//         try testing.expectEqualStrings("value3", tree.source[leaf.loc.start..leaf.loc.end]);
+//     }
+
+//     {
+//         const elem = value.values.items[2].cast(Node.Map).?;
+//         const nested = elem.values.items[0];
+//         const nested_key = tree.getToken(nested.key);
+//         try testing.expectEqual(nested_key.id, .literal);
+//         try testing.expectEqualStrings("key4", tree.source[nested_key.loc.start..nested_key.loc.end]);
+
+//         const nested_v = nested.value.?.cast(Node.Value).?;
+//         const leaf = tree.getToken(nested_v.base.start);
+//         try testing.expectEqual(leaf.id, .literal);
+//         try testing.expectEqualStrings("value4", tree.source[leaf.loc.start..leaf.loc.end]);
+//     }
+// }
+
+// test "map of list of maps with inner list" {
+//     const source =
+//         \\ outer:
+//         \\   - a: foo
+//         \\     fooers:
+//         \\       - name: inner-foo
+//         \\   - b: bar
+//         \\     fooers:
+//         \\       - name: inner-bar
+//     ;
+
+//     var tree = Tree.init(testing.allocator);
+//     defer tree.deinit();
+//     try tree.parse(source);
+
+//     try testing.expectEqual(tree.docs.items.len, 1);
+
+//     const doc = tree.docs.items[0].cast(Node.Doc).?;
+//     try testing.expectEqual(@intFromEnum(doc.base.start), 1);
+//     try testing.expectEqual(@intFromEnum(doc.base.end), tree.tokens.len - 2);
+
+//     try testing.expect(doc.value != null);
+//     try testing.expectEqual(doc.value.?.tag, .map);
+
+//     const map = doc.value.?.cast(Node.Map).?;
+//     try testing.expectEqual(@intFromEnum(map.base.start), 1);
+//     try testing.expectEqual(@intFromEnum(map.base.end), tree.tokens.len - 2);
+//     try testing.expectEqual(map.values.items.len, 1);
+
+//     const entry = map.values.items[0];
+//     const key = tree.getToken(entry.key);
+//     try testing.expectEqual(key.id, .literal);
+//     try testing.expectEqualStrings("outer", tree.source[key.loc.start..key.loc.end]);
+
+//     const value = entry.value.?.cast(Node.List).?;
+//     try testing.expectEqual(@intFromEnum(value.base.start), 5);
+//     try testing.expectEqual(@intFromEnum(value.base.end), tree.tokens.len - 2);
+//     try testing.expectEqual(value.values.items.len, 2);
+
+//     {
+//         const elem = value.values.items[0].cast(Node.Map).?;
+//         const nested = elem.values.items[0];
+//         const nested_key = tree.getToken(nested.key);
+//         try testing.expectEqual(nested_key.id, .literal);
+//         try testing.expectEqualStrings("a", tree.source[nested_key.loc.start..nested_key.loc.end]);
+
+//         const nested_v = nested.value.?.cast(Node.Value).?;
+//         const leaf = tree.getToken(nested_v.base.start);
+//         try testing.expectEqual(leaf.id, .literal);
+//         try testing.expectEqualStrings("foo", tree.source[leaf.loc.start..leaf.loc.end]);
+
+//         {
+//             const elem_with_inner_list = elem.values.items[1];
+//             const elem_with_inner_list_key = tree.getToken(elem_with_inner_list.key);
+//             try testing.expectEqual(elem_with_inner_list_key.id, .literal);
+//             try testing.expectEqualStrings("fooers", tree.source[elem_with_inner_list_key.loc.start..elem_with_inner_list_key.loc.end]);
+
+//             const elem_with_inner_list_value = elem_with_inner_list.value.?.cast(Node.List).?;
+//             try testing.expectEqual(elem_with_inner_list_value.values.items.len, 1);
+
+//             const innermost_entries = elem_with_inner_list_value.values.items[0].cast(Node.Map).?;
+//             const innermost_elem = innermost_entries.values.items[0];
+//             const innermost_key = tree.getToken(innermost_elem.key);
+//             try testing.expectEqual(innermost_key.id, .literal);
+//             try testing.expectEqualStrings("name", tree.source[innermost_key.loc.start..innermost_key.loc.end]);
+
+//             const innermost_value = innermost_elem.value.?.cast(Node.Value).?;
+//             const innermost_leaf = tree.getToken(innermost_value.base.start);
+//             try testing.expectEqual(innermost_leaf.id, .literal);
+//             try testing.expectEqualStrings("inner-foo", tree.source[innermost_leaf.loc.start..innermost_leaf.loc.end]);
+//         }
+//     }
+
+//     {
+//         const elem = value.values.items[1].cast(Node.Map).?;
+//         const nested = elem.values.items[0];
+//         const nested_key = tree.getToken(nested.key);
+//         try testing.expectEqual(nested_key.id, .literal);
+//         try testing.expectEqualStrings("b", tree.source[nested_key.loc.start..nested_key.loc.end]);
+
+//         const nested_v = nested.value.?.cast(Node.Value).?;
+//         const leaf = tree.getToken(nested_v.base.start);
+//         try testing.expectEqual(leaf.id, .literal);
+//         try testing.expectEqualStrings("bar", tree.source[leaf.loc.start..leaf.loc.end]);
+
+//         {
+//             const elem_with_inner_list = elem.values.items[1];
+//             const elem_with_inner_list_key = tree.getToken(elem_with_inner_list.key);
+//             try testing.expectEqual(elem_with_inner_list_key.id, .literal);
+//             try testing.expectEqualStrings("fooers", tree.source[elem_with_inner_list_key.loc.start..elem_with_inner_list_key.loc.end]);
+
+//             const elem_with_inner_list_value = elem_with_inner_list.value.?.cast(Node.List).?;
+//             try testing.expectEqual(elem_with_inner_list_value.values.items.len, 1);
+
+//             const innermost_entries = elem_with_inner_list_value.values.items[0].cast(Node.Map).?;
+//             const innermost_elem = innermost_entries.values.items[0];
+//             const innermost_key = tree.getToken(innermost_elem.key);
+//             try testing.expectEqual(innermost_key.id, .literal);
+//             try testing.expectEqualStrings("name", tree.source[innermost_key.loc.start..innermost_key.loc.end]);
+
+//             const innermost_value = innermost_elem.value.?.cast(Node.Value).?;
+//             const innermost_leaf = tree.getToken(innermost_value.base.start);
+//             try testing.expectEqual(innermost_leaf.id, .literal);
+//             try testing.expectEqualStrings("inner-bar", tree.source[innermost_leaf.loc.start..innermost_leaf.loc.end]);
+//         }
+//     }
+// }
+
+// test "list of lists" {
+//     const source =
+//         \\- [name        , hr, avg  ]
+//         \\- [Mark McGwire , 65, 0.278]
+//         \\- [Sammy Sosa   , 63, 0.288]
+//     ;
+
+//     var tree = Tree.init(testing.allocator);
+//     defer tree.deinit();
+//     try tree.parse(source);
+
+//     try testing.expectEqual(tree.docs.items.len, 1);
+
+//     const doc = tree.docs.items[0].cast(Node.Doc).?;
+//     try testing.expectEqual(@intFromEnum(doc.base.start), 0);
+//     try testing.expectEqual(@intFromEnum(doc.base.end), tree.tokens.len - 2);
+
+//     try testing.expect(doc.value != null);
+//     try testing.expectEqual(doc.value.?.tag, .list);
+
+//     const list = doc.value.?.cast(Node.List).?;
+//     try testing.expectEqual(@intFromEnum(list.base.start), 0);
+//     try testing.expectEqual(@intFromEnum(list.base.end), tree.tokens.len - 2);
+//     try testing.expectEqual(list.values.items.len, 3);
+
+//     {
+//         try testing.expectEqual(list.values.items[0].tag, .list);
+//         const nested = list.values.items[0].cast(Node.List).?;
+//         try testing.expectEqual(nested.values.items.len, 3);
+
+//         {
+//             try testing.expectEqual(nested.values.items[0].tag, .value);
+//             const value = nested.values.items[0].cast(Node.Value).?;
+//             const leaf = tree.getToken(value.base.start);
+//             try testing.expectEqualStrings("name", tree.source[leaf.loc.start..leaf.loc.end]);
+//         }
+
+//         {
+//             try testing.expectEqual(nested.values.items[1].tag, .value);
+//             const value = nested.values.items[1].cast(Node.Value).?;
+//             const leaf = tree.getToken(value.base.start);
+//             try testing.expectEqualStrings("hr", tree.source[leaf.loc.start..leaf.loc.end]);
+//         }
+
+//         {
+//             try testing.expectEqual(nested.values.items[2].tag, .value);
+//             const value = nested.values.items[2].cast(Node.Value).?;
+//             const leaf = tree.getToken(value.base.start);
+//             try testing.expectEqualStrings("avg", tree.source[leaf.loc.start..leaf.loc.end]);
+//         }
+//     }
+
+//     {
+//         try testing.expectEqual(list.values.items[1].tag, .list);
+//         const nested = list.values.items[1].cast(Node.List).?;
+//         try testing.expectEqual(nested.values.items.len, 3);
+
+//         {
+//             try testing.expectEqual(nested.values.items[0].tag, .value);
+//             const value = nested.values.items[0].cast(Node.Value).?;
+//             const start = tree.getToken(value.base.start);
+//             const end = tree.getToken(value.base.end);
+//             try testing.expectEqualStrings("Mark McGwire", tree.source[start.loc.start..end.loc.end]);
+//         }
+
+//         {
+//             try testing.expectEqual(nested.values.items[1].tag, .value);
+//             const value = nested.values.items[1].cast(Node.Value).?;
+//             const leaf = tree.getToken(value.base.start);
+//             try testing.expectEqualStrings("65", tree.source[leaf.loc.start..leaf.loc.end]);
+//         }
+
+//         {
+//             try testing.expectEqual(nested.values.items[2].tag, .value);
+//             const value = nested.values.items[2].cast(Node.Value).?;
+//             const leaf = tree.getToken(value.base.start);
+//             try testing.expectEqualStrings("0.278", tree.source[leaf.loc.start..leaf.loc.end]);
+//         }
+//     }
+
+//     {
+//         try testing.expectEqual(list.values.items[2].tag, .list);
+//         const nested = list.values.items[2].cast(Node.List).?;
+//         try testing.expectEqual(nested.values.items.len, 3);
+
+//         {
+//             try testing.expectEqual(nested.values.items[0].tag, .value);
+//             const value = nested.values.items[0].cast(Node.Value).?;
+//             const start = tree.getToken(value.base.start);
+//             const end = tree.getToken(value.base.end);
+//             try testing.expectEqualStrings("Sammy Sosa", tree.source[start.loc.start..end.loc.end]);
+//         }
+
+//         {
+//             try testing.expectEqual(nested.values.items[1].tag, .value);
+//             const value = nested.values.items[1].cast(Node.Value).?;
+//             const leaf = tree.getToken(value.base.start);
+//             try testing.expectEqualStrings("63", tree.source[leaf.loc.start..leaf.loc.end]);
+//         }
+
+//         {
+//             try testing.expectEqual(nested.values.items[2].tag, .value);
+//             const value = nested.values.items[2].cast(Node.Value).?;
+//             const leaf = tree.getToken(value.base.start);
+//             try testing.expectEqualStrings("0.288", tree.source[leaf.loc.start..leaf.loc.end]);
+//         }
+//     }
+// }
+
+// test "inline list" {
+//     const source =
+//         \\[name        , hr, avg  ]
+//     ;
+
+//     var tree = Tree.init(testing.allocator);
+//     defer tree.deinit();
+//     try tree.parse(source);
+
+//     try testing.expectEqual(tree.docs.items.len, 1);
+
+//     const doc = tree.docs.items[0].cast(Node.Doc).?;
+//     try testing.expectEqual(@intFromEnum(doc.base.start), 0);
+//     try testing.expectEqual(@intFromEnum(doc.base.end), tree.tokens.len - 2);
+
+//     try testing.expect(doc.value != null);
+//     try testing.expectEqual(doc.value.?.tag, .list);
+
+//     const list = doc.value.?.cast(Node.List).?;
+//     try testing.expectEqual(@intFromEnum(list.base.start), 0);
+//     try testing.expectEqual(@intFromEnum(list.base.end), tree.tokens.len - 2);
+//     try testing.expectEqual(list.values.items.len, 3);
+
+//     {
+//         try testing.expectEqual(list.values.items[0].tag, .value);
+//         const value = list.values.items[0].cast(Node.Value).?;
+//         const leaf = tree.getToken(value.base.start);
+//         try testing.expectEqualStrings("name", tree.source[leaf.loc.start..leaf.loc.end]);
+//     }
+
+//     {
+//         try testing.expectEqual(list.values.items[1].tag, .value);
+//         const value = list.values.items[1].cast(Node.Value).?;
+//         const leaf = tree.getToken(value.base.start);
+//         try testing.expectEqualStrings("hr", tree.source[leaf.loc.start..leaf.loc.end]);
+//     }
+
+//     {
+//         try testing.expectEqual(list.values.items[2].tag, .value);
+//         const value = list.values.items[2].cast(Node.Value).?;
+//         const leaf = tree.getToken(value.base.start);
+//         try testing.expectEqualStrings("avg", tree.source[leaf.loc.start..leaf.loc.end]);
+//     }
+// }
+
+// test "inline list as mapping value" {
+//     const source =
+//         \\key : [
+//         \\        name        ,
+//         \\        hr, avg  ]
+//     ;
+
+//     var tree = Tree.init(testing.allocator);
+//     defer tree.deinit();
+//     try tree.parse(source);
+
+//     try testing.expectEqual(tree.docs.items.len, 1);
+
+//     const doc = tree.docs.items[0].cast(Node.Doc).?;
+//     try testing.expectEqual(@intFromEnum(doc.base.start), 0);
+//     try testing.expectEqual(@intFromEnum(doc.base.end), tree.tokens.len - 2);
+
+//     try testing.expect(doc.value != null);
+//     try testing.expectEqual(doc.value.?.tag, .map);
+
+//     const map = doc.value.?.cast(Node.Map).?;
+//     try testing.expectEqual(@intFromEnum(map.base.start), 0);
+//     try testing.expectEqual(@intFromEnum(map.base.end), tree.tokens.len - 2);
+//     try testing.expectEqual(map.values.items.len, 1);
+
+//     const entry = map.values.items[0];
+//     const key = tree.getToken(entry.key);
+//     try testing.expectEqual(key.id, .literal);
+//     try testing.expectEqualStrings("key", tree.source[key.loc.start..key.loc.end]);
+
+//     const list = entry.value.?.cast(Node.List).?;
+//     try testing.expectEqual(@intFromEnum(list.base.start), 4);
+//     try testing.expectEqual(@intFromEnum(list.base.end), tree.tokens.len - 2);
+//     try testing.expectEqual(list.values.items.len, 3);
+
+//     {
+//         try testing.expectEqual(list.values.items[0].tag, .value);
+//         const value = list.values.items[0].cast(Node.Value).?;
+//         const leaf = tree.getToken(value.base.start);
+//         try testing.expectEqualStrings("name", tree.source[leaf.loc.start..leaf.loc.end]);
+//     }
+
+//     {
+//         try testing.expectEqual(list.values.items[1].tag, .value);
+//         const value = list.values.items[1].cast(Node.Value).?;
+//         const leaf = tree.getToken(value.base.start);
+//         try testing.expectEqualStrings("hr", tree.source[leaf.loc.start..leaf.loc.end]);
+//     }
+
+//     {
+//         try testing.expectEqual(list.values.items[2].tag, .value);
+//         const value = list.values.items[2].cast(Node.Value).?;
+//         const leaf = tree.getToken(value.base.start);
+//         try testing.expectEqualStrings("avg", tree.source[leaf.loc.start..leaf.loc.end]);
+//     }
+// }
+
+// fn parseSuccess(comptime source: []const u8) !void {
+//     var tree = Tree.init(testing.allocator);
+//     defer tree.deinit();
+//     try tree.parse(source);
+// }
+
+// fn parseError(comptime source: []const u8, err: parse.ParseError) !void {
+//     var tree = Tree.init(testing.allocator);
+//     defer tree.deinit();
+//     try testing.expectError(err, tree.parse(source));
+// }
+
+// test "empty doc with spaces and comments" {
+//     try parseSuccess(
+//         \\
+//         \\
+//         \\   # this is a comment in a weird place
+//         \\# and this one is too
+//     );
+// }
+
+// test "comment between --- and ! in document start" {
+//     try parseError(
+//         \\--- # what is it?
+//         \\!
+//     , error.UnexpectedToken);
+// }
+
+// test "correct doc start with tag" {
+//     try parseSuccess(
+//         \\--- !some-tag
+//         \\
+//     );
+// }
+
+// test "doc close without explicit doc open" {
+//     try parseError(
+//         \\
+//         \\
+//         \\# something cool
+//         \\...
+//     , error.UnexpectedToken);
+// }
+
+// test "doc open and close are ok" {
+//     try parseSuccess(
+//         \\---
+//         \\# first doc
+//         \\
+//         \\
+//         \\---
+//         \\# second doc
+//         \\
+//         \\
+//         \\...
+//     );
+// }
+
+// test "doc with a single string is ok" {
+//     try parseSuccess(
+//         \\a string of some sort
+//         \\
+//     );
+// }
+
+// test "explicit doc with a single string is ok" {
+//     try parseSuccess(
+//         \\--- !anchor
+//         \\# nothing to see here except one string
+//         \\  # not a lot to go on with
+//         \\a single string
+//         \\...
+//     );
+// }
+
+// test "doc with two string is bad" {
+//     try parseError(
+//         \\first
+//         \\second
+//         \\# this should fail already
+//     , error.UnexpectedToken);
+// }
+
+// test "single quote string can have new lines" {
+//     try parseSuccess(
+//         \\'what is this
+//         \\ thing?'
+//     );
+// }
+
+// test "single quote string on one line is fine" {
+//     try parseSuccess(
+//         \\'here''s an apostrophe'
+//     );
+// }
+
+// test "double quote string can have new lines" {
+//     try parseSuccess(
+//         \\"what is this
+//         \\ thing?"
+//     );
+// }
+
+// test "double quote string on one line is fine" {
+//     try parseSuccess(
+//         \\"a newline\nand a\ttab"
+//     );
+// }
+
+// test "map with key and value literals" {
+//     try parseSuccess(
+//         \\key1: val1
+//         \\key2 : val2
+//     );
+// }
+
+// test "map of maps" {
+//     try parseSuccess(
+//         \\
+//         \\# the first key
+//         \\key1:
+//         \\  # the first subkey
+//         \\  key1_1: 0
+//         \\  key1_2: 1
+//         \\# the second key
+//         \\key2:
+//         \\  key2_1: -1
+//         \\  key2_2: -2
+//         \\# the end of map
+//     );
+// }
+
+// test "map value indicator needs to be on the same line" {
+//     try parseError(
+//         \\a
+//         \\  : b
+//     , error.UnexpectedToken);
+// }
+
+// test "value needs to be indented" {
+//     try parseError(
+//         \\a:
+//         \\b
+//     , error.MalformedYaml);
+// }
+
+// test "comment between a key and a value is fine" {
+//     try parseSuccess(
+//         \\a:
+//         \\  # this is a value
+//         \\  b
+//     );
+// }
+
+// test "simple list" {
+//     try parseSuccess(
+//         \\# first el
+//         \\- a
+//         \\# second el
+//         \\-  b
+//         \\# third el
+//         \\-   c
+//     );
+// }
+
+// test "list indentation matters" {
+//     try parseError(
+//         \\  - a
+//         \\- b
+//     , error.UnexpectedToken);
+
+//     try parseSuccess(
+//         \\- a
+//         \\  - b
+//     );
+// }
+
+// test "unindented list is fine too" {
+//     try parseSuccess(
+//         \\a:
+//         \\- 0
+//         \\- 1
+//     );
+// }
+
+// test "empty values in a map" {
+//     try parseSuccess(
+//         \\a:
+//         \\b:
+//         \\- 0
+//     );
+// }
+
+// test "weirdly nested map of maps of lists" {
+//     try parseSuccess(
+//         \\a:
+//         \\ b:
+//         \\  - 0
+//         \\  - 1
+//     );
+// }
+
+// test "square brackets denote a list" {
+//     try parseSuccess(
+//         \\[ a,
+//         \\  b, c ]
+//     );
+// }
+
+// test "empty list" {
+//     try parseSuccess(
+//         \\[ ]
+//     );
+// }
+
+// test "empty map" {
+//     try parseSuccess(
+//         \\a:
+//         \\  b: {}
+//         \\  c: { }
+//     );
+// }
+
+// test "comment within a bracketed list is an error" {
+//     try parseError(
+//         \\[ # something
+//         \\]
+//     , error.MalformedYaml);
+// }
+
+// test "mixed ints with floats in a list" {
+//     try parseSuccess(
+//         \\[0, 1.0]
+//     );
+// }

--- a/src/parse/test.zig
+++ b/src/parse/test.zig
@@ -7,12 +7,13 @@ const Node = parse.Node;
 const Parser = parse.Parser;
 const Tree = parse.Tree;
 
-fn expectMapEntryWithStringValue(
-    tree: Tree,
-    entry_data: parse.Map.Entry,
-    exp_key: []const u8,
-    exp_value: []const u8,
-) !void {
+fn expectNodeScope(parser: Parser, node: Node.Index, from: usize, to: usize) !void {
+    const scope = parser.nodes_scopes.get(node).?;
+    try testing.expectEqual(from, @intFromEnum(scope.start));
+    try testing.expectEqual(to, @intFromEnum(scope.end));
+}
+
+fn expectValueMapEntry(tree: Tree, entry_data: parse.Map.Entry, exp_key: []const u8, exp_value: []const u8) !void {
     const key = tree.getToken(entry_data.key);
     try testing.expectEqual(key.id, .literal);
     try testing.expectEqualStrings(exp_key, tree.getRaw(entry_data.key, entry_data.key));
@@ -24,6 +25,25 @@ fn expectMapEntryWithStringValue(
     const value = maybe_value.unwrap().?;
     const string = tree.nodeData(value).string.slice(tree);
     try testing.expectEqualStrings(exp_value, string);
+}
+
+fn expectValueListEntry(tree: Tree, entry_data: parse.List.Entry, exp_value: []const u8) !void {
+    const value = entry_data.value;
+    try testing.expectEqual(.value, tree.nodeTag(value));
+
+    const string = tree.nodeData(value).string.slice(tree);
+    try testing.expectEqualStrings(exp_value, string);
+}
+
+fn expectNestedMapListEntry(tree: Tree, list_entry_data: parse.List.Entry, exp_key: []const u8, exp_value: []const u8) !void {
+    const value = list_entry_data.value;
+    try testing.expectEqual(.map, tree.nodeTag(value));
+
+    const map_data = tree.extraData(parse.Map, tree.nodeData(value).extra);
+    try testing.expectEqual(1, map_data.data.map_len);
+
+    const entry_data = tree.extraData(parse.Map.Entry, map_data.end);
+    try expectValueMapEntry(tree, entry_data.data, exp_key, exp_value);
 }
 
 test "explicit doc" {
@@ -46,9 +66,7 @@ test "explicit doc" {
     const doc = tree.docs[0];
     try testing.expectEqual(.doc_with_directive, tree.nodeTag(doc));
 
-    const doc_scope = parser.nodes_scopes.get(doc).?;
-    try testing.expectEqual(0, @intFromEnum(doc_scope.start));
-    try testing.expectEqual(tree.tokens.len - 2, @intFromEnum(doc_scope.end));
+    try expectNodeScope(parser, doc, 0, tree.tokens.len - 2);
 
     const directive = tree.getDirective(doc).?;
     try testing.expectEqualStrings("tapi-tbd", directive);
@@ -58,18 +76,17 @@ test "explicit doc" {
     try testing.expectEqual(.map, tree.nodeTag(doc_value.unwrap().?));
 
     const map = doc_value.unwrap().?;
-    const map_scope = parser.nodes_scopes.get(map).?;
-    try testing.expectEqual(5, @intFromEnum(map_scope.start));
-    try testing.expectEqual(14, @intFromEnum(map_scope.end));
+
+    try expectNodeScope(parser, map, 5, 14);
 
     const map_data = tree.extraData(parse.Map, tree.nodeData(map).extra);
     try testing.expectEqual(2, map_data.data.map_len);
 
     var entry_data = tree.extraData(parse.Map.Entry, map_data.end);
-    try expectMapEntryWithStringValue(tree, entry_data.data, "tbd-version", "4");
+    try expectValueMapEntry(tree, entry_data.data, "tbd-version", "4");
 
     entry_data = tree.extraData(parse.Map.Entry, entry_data.end);
-    try expectMapEntryWithStringValue(tree, entry_data.data, "abc-version", "5");
+    try expectValueMapEntry(tree, entry_data.data, "abc-version", "5");
 }
 
 test "leaf in quotes" {
@@ -91,30 +108,27 @@ test "leaf in quotes" {
     const doc = tree.docs[0];
     try testing.expectEqual(.doc, tree.nodeTag(doc));
 
-    const doc_scope = parser.nodes_scopes.get(doc).?;
-    try testing.expectEqual(0, @intFromEnum(doc_scope.start));
-    try testing.expectEqual(tree.tokens.len - 2, @intFromEnum(doc_scope.end));
+    try expectNodeScope(parser, doc, 0, tree.tokens.len - 2);
 
     const doc_value = tree.nodeData(doc).value;
     try testing.expect(doc_value != .none);
     try testing.expectEqual(.map, tree.nodeTag(doc_value.unwrap().?));
 
     const map = doc_value.unwrap().?;
-    const map_scope = parser.nodes_scopes.get(map).?;
-    try testing.expectEqual(0, @intFromEnum(map_scope.start));
-    try testing.expectEqual(tree.tokens.len - 2, @intFromEnum(map_scope.end));
+
+    try expectNodeScope(parser, map, 0, tree.tokens.len - 2);
 
     const map_data = tree.extraData(parse.Map, tree.nodeData(map).extra);
     try testing.expectEqual(3, map_data.data.map_len);
 
     var entry_data = tree.extraData(parse.Map.Entry, map_data.end);
-    try expectMapEntryWithStringValue(tree, entry_data.data, "key1", "no quotes, comma");
+    try expectValueMapEntry(tree, entry_data.data, "key1", "no quotes, comma");
 
     entry_data = tree.extraData(parse.Map.Entry, entry_data.end);
-    try expectMapEntryWithStringValue(tree, entry_data.data, "key2", "single quoted");
+    try expectValueMapEntry(tree, entry_data.data, "key2", "single quoted");
 
     entry_data = tree.extraData(parse.Map.Entry, entry_data.end);
-    try expectMapEntryWithStringValue(tree, entry_data.data, "key3", "double quoted");
+    try expectValueMapEntry(tree, entry_data.data, "key3", "double quoted");
 }
 
 test "nested maps" {
@@ -137,18 +151,15 @@ test "nested maps" {
     const doc = tree.docs[0];
     try testing.expectEqual(.doc, tree.nodeTag(doc));
 
-    const doc_scope = parser.nodes_scopes.get(doc).?;
-    try testing.expectEqual(0, @intFromEnum(doc_scope.start));
-    try testing.expectEqual(tree.tokens.len - 2, @intFromEnum(doc_scope.end));
+    try expectNodeScope(parser, doc, 0, tree.tokens.len - 2);
 
     const doc_value = tree.nodeData(doc).value;
     try testing.expect(doc_value != .none);
     try testing.expectEqual(.map, tree.nodeTag(doc_value.unwrap().?));
 
     const map = doc_value.unwrap().?;
-    const map_scope = parser.nodes_scopes.get(map).?;
-    try testing.expectEqual(0, @intFromEnum(map_scope.start));
-    try testing.expectEqual(tree.tokens.len - 2, @intFromEnum(map_scope.end));
+
+    try expectNodeScope(parser, map, 0, tree.tokens.len - 2);
 
     const map_data = tree.extraData(parse.Map, tree.nodeData(map).extra);
     try testing.expectEqual(2, map_data.data.map_len);
@@ -164,708 +175,674 @@ test "nested maps" {
         try testing.expectEqual(.map, tree.nodeTag(maybe_nested_map.unwrap().?));
 
         const nested_map = maybe_nested_map.unwrap().?;
-        const nested_map_scope = parser.nodes_scopes.get(nested_map).?;
-        try testing.expectEqual(4, @intFromEnum(nested_map_scope.start));
-        try testing.expectEqual(16, @intFromEnum(nested_map_scope.end));
+
+        try expectNodeScope(parser, nested_map, 4, 16);
 
         const nested_map_data = tree.extraData(parse.Map, tree.nodeData(nested_map).extra);
         try testing.expectEqual(2, nested_map_data.data.map_len);
 
         var nested_entry_data = tree.extraData(parse.Map.Entry, nested_map_data.end);
-        try expectMapEntryWithStringValue(tree, nested_entry_data.data, "key1_1", "value1_1");
+        try expectValueMapEntry(tree, nested_entry_data.data, "key1_1", "value1_1");
 
         nested_entry_data = tree.extraData(parse.Map.Entry, nested_entry_data.end);
-        try expectMapEntryWithStringValue(tree, nested_entry_data.data, "key1_2", "value1_2");
+        try expectValueMapEntry(tree, nested_entry_data.data, "key1_2", "value1_2");
     }
 
     entry_data = tree.extraData(parse.Map.Entry, entry_data.end);
-    try expectMapEntryWithStringValue(tree, entry_data.data, "key2", "value2");
+    try expectValueMapEntry(tree, entry_data.data, "key2", "value2");
 }
 
-// test "map of list of values" {
-//     const source =
-//         \\ints:
-//         \\  - 0
-//         \\  - 1
-//         \\  - 2
-//     ;
-//     var tree = Tree.init(testing.allocator);
-//     defer tree.deinit();
-//     try tree.parse(source);
-
-//     try testing.expectEqual(tree.docs.items.len, 1);
-
-//     const doc = tree.docs.items[0].cast(Node.Doc).?;
-//     try testing.expectEqual(@intFromEnum(doc.base.start), 0);
-//     try testing.expectEqual(@intFromEnum(doc.base.end), tree.tokens.len - 2);
-
-//     try testing.expect(doc.value != null);
-//     try testing.expectEqual(doc.value.?.tag, .map);
-
-//     const map = doc.value.?.cast(Node.Map).?;
-//     try testing.expectEqual(@intFromEnum(map.base.start), 0);
-//     try testing.expectEqual(@intFromEnum(map.base.end), tree.tokens.len - 2);
-//     try testing.expectEqual(map.values.items.len, 1);
-
-//     const entry = map.values.items[0];
-//     const key = tree.getToken(entry.key);
-//     try testing.expectEqual(key.id, .literal);
-//     try testing.expectEqualStrings("ints", tree.source[key.loc.start..key.loc.end]);
-
-//     const value = entry.value.?.cast(Node.List).?;
-//     try testing.expectEqual(@intFromEnum(value.base.start), 4);
-//     try testing.expectEqual(@intFromEnum(value.base.end), tree.tokens.len - 2);
-//     try testing.expectEqual(value.values.items.len, 3);
-
-//     {
-//         const elem = value.values.items[0].cast(Node.Value).?;
-//         const leaf = tree.getToken(elem.base.start);
-//         try testing.expectEqual(leaf.id, .literal);
-//         try testing.expectEqualStrings("0", tree.source[leaf.loc.start..leaf.loc.end]);
-//     }
-
-//     {
-//         const elem = value.values.items[1].cast(Node.Value).?;
-//         const leaf = tree.getToken(elem.base.start);
-//         try testing.expectEqual(leaf.id, .literal);
-//         try testing.expectEqualStrings("1", tree.source[leaf.loc.start..leaf.loc.end]);
-//     }
-
-//     {
-//         const elem = value.values.items[2].cast(Node.Value).?;
-//         const leaf = tree.getToken(elem.base.start);
-//         try testing.expectEqual(leaf.id, .literal);
-//         try testing.expectEqualStrings("2", tree.source[leaf.loc.start..leaf.loc.end]);
-//     }
-// }
-
-// test "map of list of maps" {
-//     const source =
-//         \\key1:
-//         \\- key2 : value2
-//         \\- key3 : value3
-//         \\- key4 : value4
-//     ;
-
-//     var tree = Tree.init(testing.allocator);
-//     defer tree.deinit();
-//     try tree.parse(source);
-
-//     try testing.expectEqual(tree.docs.items.len, 1);
-
-//     const doc = tree.docs.items[0].cast(Node.Doc).?;
-//     try testing.expectEqual(@intFromEnum(doc.base.start), 0);
-//     try testing.expectEqual(@intFromEnum(doc.base.end), tree.tokens.len - 2);
-
-//     try testing.expect(doc.value != null);
-//     try testing.expectEqual(doc.value.?.tag, .map);
-
-//     const map = doc.value.?.cast(Node.Map).?;
-//     try testing.expectEqual(@intFromEnum(map.base.start), 0);
-//     try testing.expectEqual(@intFromEnum(map.base.end), tree.tokens.len - 2);
-//     try testing.expectEqual(map.values.items.len, 1);
-
-//     const entry = map.values.items[0];
-//     const key = tree.getToken(entry.key);
-//     try testing.expectEqual(key.id, .literal);
-//     try testing.expectEqualStrings("key1", tree.source[key.loc.start..key.loc.end]);
-
-//     const value = entry.value.?.cast(Node.List).?;
-//     try testing.expectEqual(@intFromEnum(value.base.start), 3);
-//     try testing.expectEqual(@intFromEnum(value.base.end), tree.tokens.len - 2);
-//     try testing.expectEqual(value.values.items.len, 3);
-
-//     {
-//         const elem = value.values.items[0].cast(Node.Map).?;
-//         const nested = elem.values.items[0];
-//         const nested_key = tree.getToken(nested.key);
-//         try testing.expectEqual(nested_key.id, .literal);
-//         try testing.expectEqualStrings("key2", tree.source[nested_key.loc.start..nested_key.loc.end]);
-
-//         const nested_v = nested.value.?.cast(Node.Value).?;
-//         const leaf = tree.getToken(nested_v.base.start);
-//         try testing.expectEqual(leaf.id, .literal);
-//         try testing.expectEqualStrings("value2", tree.source[leaf.loc.start..leaf.loc.end]);
-//     }
-
-//     {
-//         const elem = value.values.items[1].cast(Node.Map).?;
-//         const nested = elem.values.items[0];
-//         const nested_key = tree.getToken(nested.key);
-//         try testing.expectEqual(nested_key.id, .literal);
-//         try testing.expectEqualStrings("key3", tree.source[nested_key.loc.start..nested_key.loc.end]);
-
-//         const nested_v = nested.value.?.cast(Node.Value).?;
-//         const leaf = tree.getToken(nested_v.base.start);
-//         try testing.expectEqual(leaf.id, .literal);
-//         try testing.expectEqualStrings("value3", tree.source[leaf.loc.start..leaf.loc.end]);
-//     }
-
-//     {
-//         const elem = value.values.items[2].cast(Node.Map).?;
-//         const nested = elem.values.items[0];
-//         const nested_key = tree.getToken(nested.key);
-//         try testing.expectEqual(nested_key.id, .literal);
-//         try testing.expectEqualStrings("key4", tree.source[nested_key.loc.start..nested_key.loc.end]);
-
-//         const nested_v = nested.value.?.cast(Node.Value).?;
-//         const leaf = tree.getToken(nested_v.base.start);
-//         try testing.expectEqual(leaf.id, .literal);
-//         try testing.expectEqualStrings("value4", tree.source[leaf.loc.start..leaf.loc.end]);
-//     }
-// }
-
-// test "map of list of maps with inner list" {
-//     const source =
-//         \\ outer:
-//         \\   - a: foo
-//         \\     fooers:
-//         \\       - name: inner-foo
-//         \\   - b: bar
-//         \\     fooers:
-//         \\       - name: inner-bar
-//     ;
-
-//     var tree = Tree.init(testing.allocator);
-//     defer tree.deinit();
-//     try tree.parse(source);
-
-//     try testing.expectEqual(tree.docs.items.len, 1);
-
-//     const doc = tree.docs.items[0].cast(Node.Doc).?;
-//     try testing.expectEqual(@intFromEnum(doc.base.start), 1);
-//     try testing.expectEqual(@intFromEnum(doc.base.end), tree.tokens.len - 2);
-
-//     try testing.expect(doc.value != null);
-//     try testing.expectEqual(doc.value.?.tag, .map);
-
-//     const map = doc.value.?.cast(Node.Map).?;
-//     try testing.expectEqual(@intFromEnum(map.base.start), 1);
-//     try testing.expectEqual(@intFromEnum(map.base.end), tree.tokens.len - 2);
-//     try testing.expectEqual(map.values.items.len, 1);
-
-//     const entry = map.values.items[0];
-//     const key = tree.getToken(entry.key);
-//     try testing.expectEqual(key.id, .literal);
-//     try testing.expectEqualStrings("outer", tree.source[key.loc.start..key.loc.end]);
-
-//     const value = entry.value.?.cast(Node.List).?;
-//     try testing.expectEqual(@intFromEnum(value.base.start), 5);
-//     try testing.expectEqual(@intFromEnum(value.base.end), tree.tokens.len - 2);
-//     try testing.expectEqual(value.values.items.len, 2);
-
-//     {
-//         const elem = value.values.items[0].cast(Node.Map).?;
-//         const nested = elem.values.items[0];
-//         const nested_key = tree.getToken(nested.key);
-//         try testing.expectEqual(nested_key.id, .literal);
-//         try testing.expectEqualStrings("a", tree.source[nested_key.loc.start..nested_key.loc.end]);
-
-//         const nested_v = nested.value.?.cast(Node.Value).?;
-//         const leaf = tree.getToken(nested_v.base.start);
-//         try testing.expectEqual(leaf.id, .literal);
-//         try testing.expectEqualStrings("foo", tree.source[leaf.loc.start..leaf.loc.end]);
-
-//         {
-//             const elem_with_inner_list = elem.values.items[1];
-//             const elem_with_inner_list_key = tree.getToken(elem_with_inner_list.key);
-//             try testing.expectEqual(elem_with_inner_list_key.id, .literal);
-//             try testing.expectEqualStrings("fooers", tree.source[elem_with_inner_list_key.loc.start..elem_with_inner_list_key.loc.end]);
-
-//             const elem_with_inner_list_value = elem_with_inner_list.value.?.cast(Node.List).?;
-//             try testing.expectEqual(elem_with_inner_list_value.values.items.len, 1);
-
-//             const innermost_entries = elem_with_inner_list_value.values.items[0].cast(Node.Map).?;
-//             const innermost_elem = innermost_entries.values.items[0];
-//             const innermost_key = tree.getToken(innermost_elem.key);
-//             try testing.expectEqual(innermost_key.id, .literal);
-//             try testing.expectEqualStrings("name", tree.source[innermost_key.loc.start..innermost_key.loc.end]);
-
-//             const innermost_value = innermost_elem.value.?.cast(Node.Value).?;
-//             const innermost_leaf = tree.getToken(innermost_value.base.start);
-//             try testing.expectEqual(innermost_leaf.id, .literal);
-//             try testing.expectEqualStrings("inner-foo", tree.source[innermost_leaf.loc.start..innermost_leaf.loc.end]);
-//         }
-//     }
-
-//     {
-//         const elem = value.values.items[1].cast(Node.Map).?;
-//         const nested = elem.values.items[0];
-//         const nested_key = tree.getToken(nested.key);
-//         try testing.expectEqual(nested_key.id, .literal);
-//         try testing.expectEqualStrings("b", tree.source[nested_key.loc.start..nested_key.loc.end]);
-
-//         const nested_v = nested.value.?.cast(Node.Value).?;
-//         const leaf = tree.getToken(nested_v.base.start);
-//         try testing.expectEqual(leaf.id, .literal);
-//         try testing.expectEqualStrings("bar", tree.source[leaf.loc.start..leaf.loc.end]);
-
-//         {
-//             const elem_with_inner_list = elem.values.items[1];
-//             const elem_with_inner_list_key = tree.getToken(elem_with_inner_list.key);
-//             try testing.expectEqual(elem_with_inner_list_key.id, .literal);
-//             try testing.expectEqualStrings("fooers", tree.source[elem_with_inner_list_key.loc.start..elem_with_inner_list_key.loc.end]);
-
-//             const elem_with_inner_list_value = elem_with_inner_list.value.?.cast(Node.List).?;
-//             try testing.expectEqual(elem_with_inner_list_value.values.items.len, 1);
-
-//             const innermost_entries = elem_with_inner_list_value.values.items[0].cast(Node.Map).?;
-//             const innermost_elem = innermost_entries.values.items[0];
-//             const innermost_key = tree.getToken(innermost_elem.key);
-//             try testing.expectEqual(innermost_key.id, .literal);
-//             try testing.expectEqualStrings("name", tree.source[innermost_key.loc.start..innermost_key.loc.end]);
-
-//             const innermost_value = innermost_elem.value.?.cast(Node.Value).?;
-//             const innermost_leaf = tree.getToken(innermost_value.base.start);
-//             try testing.expectEqual(innermost_leaf.id, .literal);
-//             try testing.expectEqualStrings("inner-bar", tree.source[innermost_leaf.loc.start..innermost_leaf.loc.end]);
-//         }
-//     }
-// }
-
-// test "list of lists" {
-//     const source =
-//         \\- [name        , hr, avg  ]
-//         \\- [Mark McGwire , 65, 0.278]
-//         \\- [Sammy Sosa   , 63, 0.288]
-//     ;
-
-//     var tree = Tree.init(testing.allocator);
-//     defer tree.deinit();
-//     try tree.parse(source);
-
-//     try testing.expectEqual(tree.docs.items.len, 1);
-
-//     const doc = tree.docs.items[0].cast(Node.Doc).?;
-//     try testing.expectEqual(@intFromEnum(doc.base.start), 0);
-//     try testing.expectEqual(@intFromEnum(doc.base.end), tree.tokens.len - 2);
-
-//     try testing.expect(doc.value != null);
-//     try testing.expectEqual(doc.value.?.tag, .list);
-
-//     const list = doc.value.?.cast(Node.List).?;
-//     try testing.expectEqual(@intFromEnum(list.base.start), 0);
-//     try testing.expectEqual(@intFromEnum(list.base.end), tree.tokens.len - 2);
-//     try testing.expectEqual(list.values.items.len, 3);
-
-//     {
-//         try testing.expectEqual(list.values.items[0].tag, .list);
-//         const nested = list.values.items[0].cast(Node.List).?;
-//         try testing.expectEqual(nested.values.items.len, 3);
-
-//         {
-//             try testing.expectEqual(nested.values.items[0].tag, .value);
-//             const value = nested.values.items[0].cast(Node.Value).?;
-//             const leaf = tree.getToken(value.base.start);
-//             try testing.expectEqualStrings("name", tree.source[leaf.loc.start..leaf.loc.end]);
-//         }
-
-//         {
-//             try testing.expectEqual(nested.values.items[1].tag, .value);
-//             const value = nested.values.items[1].cast(Node.Value).?;
-//             const leaf = tree.getToken(value.base.start);
-//             try testing.expectEqualStrings("hr", tree.source[leaf.loc.start..leaf.loc.end]);
-//         }
-
-//         {
-//             try testing.expectEqual(nested.values.items[2].tag, .value);
-//             const value = nested.values.items[2].cast(Node.Value).?;
-//             const leaf = tree.getToken(value.base.start);
-//             try testing.expectEqualStrings("avg", tree.source[leaf.loc.start..leaf.loc.end]);
-//         }
-//     }
-
-//     {
-//         try testing.expectEqual(list.values.items[1].tag, .list);
-//         const nested = list.values.items[1].cast(Node.List).?;
-//         try testing.expectEqual(nested.values.items.len, 3);
-
-//         {
-//             try testing.expectEqual(nested.values.items[0].tag, .value);
-//             const value = nested.values.items[0].cast(Node.Value).?;
-//             const start = tree.getToken(value.base.start);
-//             const end = tree.getToken(value.base.end);
-//             try testing.expectEqualStrings("Mark McGwire", tree.source[start.loc.start..end.loc.end]);
-//         }
-
-//         {
-//             try testing.expectEqual(nested.values.items[1].tag, .value);
-//             const value = nested.values.items[1].cast(Node.Value).?;
-//             const leaf = tree.getToken(value.base.start);
-//             try testing.expectEqualStrings("65", tree.source[leaf.loc.start..leaf.loc.end]);
-//         }
-
-//         {
-//             try testing.expectEqual(nested.values.items[2].tag, .value);
-//             const value = nested.values.items[2].cast(Node.Value).?;
-//             const leaf = tree.getToken(value.base.start);
-//             try testing.expectEqualStrings("0.278", tree.source[leaf.loc.start..leaf.loc.end]);
-//         }
-//     }
-
-//     {
-//         try testing.expectEqual(list.values.items[2].tag, .list);
-//         const nested = list.values.items[2].cast(Node.List).?;
-//         try testing.expectEqual(nested.values.items.len, 3);
-
-//         {
-//             try testing.expectEqual(nested.values.items[0].tag, .value);
-//             const value = nested.values.items[0].cast(Node.Value).?;
-//             const start = tree.getToken(value.base.start);
-//             const end = tree.getToken(value.base.end);
-//             try testing.expectEqualStrings("Sammy Sosa", tree.source[start.loc.start..end.loc.end]);
-//         }
-
-//         {
-//             try testing.expectEqual(nested.values.items[1].tag, .value);
-//             const value = nested.values.items[1].cast(Node.Value).?;
-//             const leaf = tree.getToken(value.base.start);
-//             try testing.expectEqualStrings("63", tree.source[leaf.loc.start..leaf.loc.end]);
-//         }
-
-//         {
-//             try testing.expectEqual(nested.values.items[2].tag, .value);
-//             const value = nested.values.items[2].cast(Node.Value).?;
-//             const leaf = tree.getToken(value.base.start);
-//             try testing.expectEqualStrings("0.288", tree.source[leaf.loc.start..leaf.loc.end]);
-//         }
-//     }
-// }
-
-// test "inline list" {
-//     const source =
-//         \\[name        , hr, avg  ]
-//     ;
-
-//     var tree = Tree.init(testing.allocator);
-//     defer tree.deinit();
-//     try tree.parse(source);
-
-//     try testing.expectEqual(tree.docs.items.len, 1);
-
-//     const doc = tree.docs.items[0].cast(Node.Doc).?;
-//     try testing.expectEqual(@intFromEnum(doc.base.start), 0);
-//     try testing.expectEqual(@intFromEnum(doc.base.end), tree.tokens.len - 2);
-
-//     try testing.expect(doc.value != null);
-//     try testing.expectEqual(doc.value.?.tag, .list);
-
-//     const list = doc.value.?.cast(Node.List).?;
-//     try testing.expectEqual(@intFromEnum(list.base.start), 0);
-//     try testing.expectEqual(@intFromEnum(list.base.end), tree.tokens.len - 2);
-//     try testing.expectEqual(list.values.items.len, 3);
-
-//     {
-//         try testing.expectEqual(list.values.items[0].tag, .value);
-//         const value = list.values.items[0].cast(Node.Value).?;
-//         const leaf = tree.getToken(value.base.start);
-//         try testing.expectEqualStrings("name", tree.source[leaf.loc.start..leaf.loc.end]);
-//     }
-
-//     {
-//         try testing.expectEqual(list.values.items[1].tag, .value);
-//         const value = list.values.items[1].cast(Node.Value).?;
-//         const leaf = tree.getToken(value.base.start);
-//         try testing.expectEqualStrings("hr", tree.source[leaf.loc.start..leaf.loc.end]);
-//     }
-
-//     {
-//         try testing.expectEqual(list.values.items[2].tag, .value);
-//         const value = list.values.items[2].cast(Node.Value).?;
-//         const leaf = tree.getToken(value.base.start);
-//         try testing.expectEqualStrings("avg", tree.source[leaf.loc.start..leaf.loc.end]);
-//     }
-// }
-
-// test "inline list as mapping value" {
-//     const source =
-//         \\key : [
-//         \\        name        ,
-//         \\        hr, avg  ]
-//     ;
-
-//     var tree = Tree.init(testing.allocator);
-//     defer tree.deinit();
-//     try tree.parse(source);
-
-//     try testing.expectEqual(tree.docs.items.len, 1);
-
-//     const doc = tree.docs.items[0].cast(Node.Doc).?;
-//     try testing.expectEqual(@intFromEnum(doc.base.start), 0);
-//     try testing.expectEqual(@intFromEnum(doc.base.end), tree.tokens.len - 2);
-
-//     try testing.expect(doc.value != null);
-//     try testing.expectEqual(doc.value.?.tag, .map);
-
-//     const map = doc.value.?.cast(Node.Map).?;
-//     try testing.expectEqual(@intFromEnum(map.base.start), 0);
-//     try testing.expectEqual(@intFromEnum(map.base.end), tree.tokens.len - 2);
-//     try testing.expectEqual(map.values.items.len, 1);
-
-//     const entry = map.values.items[0];
-//     const key = tree.getToken(entry.key);
-//     try testing.expectEqual(key.id, .literal);
-//     try testing.expectEqualStrings("key", tree.source[key.loc.start..key.loc.end]);
-
-//     const list = entry.value.?.cast(Node.List).?;
-//     try testing.expectEqual(@intFromEnum(list.base.start), 4);
-//     try testing.expectEqual(@intFromEnum(list.base.end), tree.tokens.len - 2);
-//     try testing.expectEqual(list.values.items.len, 3);
-
-//     {
-//         try testing.expectEqual(list.values.items[0].tag, .value);
-//         const value = list.values.items[0].cast(Node.Value).?;
-//         const leaf = tree.getToken(value.base.start);
-//         try testing.expectEqualStrings("name", tree.source[leaf.loc.start..leaf.loc.end]);
-//     }
-
-//     {
-//         try testing.expectEqual(list.values.items[1].tag, .value);
-//         const value = list.values.items[1].cast(Node.Value).?;
-//         const leaf = tree.getToken(value.base.start);
-//         try testing.expectEqualStrings("hr", tree.source[leaf.loc.start..leaf.loc.end]);
-//     }
-
-//     {
-//         try testing.expectEqual(list.values.items[2].tag, .value);
-//         const value = list.values.items[2].cast(Node.Value).?;
-//         const leaf = tree.getToken(value.base.start);
-//         try testing.expectEqualStrings("avg", tree.source[leaf.loc.start..leaf.loc.end]);
-//     }
-// }
-
-// fn parseSuccess(comptime source: []const u8) !void {
-//     var tree = Tree.init(testing.allocator);
-//     defer tree.deinit();
-//     try tree.parse(source);
-// }
-
-// fn parseError(comptime source: []const u8, err: parse.ParseError) !void {
-//     var tree = Tree.init(testing.allocator);
-//     defer tree.deinit();
-//     try testing.expectError(err, tree.parse(source));
-// }
-
-// test "empty doc with spaces and comments" {
-//     try parseSuccess(
-//         \\
-//         \\
-//         \\   # this is a comment in a weird place
-//         \\# and this one is too
-//     );
-// }
-
-// test "comment between --- and ! in document start" {
-//     try parseError(
-//         \\--- # what is it?
-//         \\!
-//     , error.UnexpectedToken);
-// }
-
-// test "correct doc start with tag" {
-//     try parseSuccess(
-//         \\--- !some-tag
-//         \\
-//     );
-// }
-
-// test "doc close without explicit doc open" {
-//     try parseError(
-//         \\
-//         \\
-//         \\# something cool
-//         \\...
-//     , error.UnexpectedToken);
-// }
-
-// test "doc open and close are ok" {
-//     try parseSuccess(
-//         \\---
-//         \\# first doc
-//         \\
-//         \\
-//         \\---
-//         \\# second doc
-//         \\
-//         \\
-//         \\...
-//     );
-// }
-
-// test "doc with a single string is ok" {
-//     try parseSuccess(
-//         \\a string of some sort
-//         \\
-//     );
-// }
-
-// test "explicit doc with a single string is ok" {
-//     try parseSuccess(
-//         \\--- !anchor
-//         \\# nothing to see here except one string
-//         \\  # not a lot to go on with
-//         \\a single string
-//         \\...
-//     );
-// }
-
-// test "doc with two string is bad" {
-//     try parseError(
-//         \\first
-//         \\second
-//         \\# this should fail already
-//     , error.UnexpectedToken);
-// }
-
-// test "single quote string can have new lines" {
-//     try parseSuccess(
-//         \\'what is this
-//         \\ thing?'
-//     );
-// }
-
-// test "single quote string on one line is fine" {
-//     try parseSuccess(
-//         \\'here''s an apostrophe'
-//     );
-// }
-
-// test "double quote string can have new lines" {
-//     try parseSuccess(
-//         \\"what is this
-//         \\ thing?"
-//     );
-// }
-
-// test "double quote string on one line is fine" {
-//     try parseSuccess(
-//         \\"a newline\nand a\ttab"
-//     );
-// }
-
-// test "map with key and value literals" {
-//     try parseSuccess(
-//         \\key1: val1
-//         \\key2 : val2
-//     );
-// }
-
-// test "map of maps" {
-//     try parseSuccess(
-//         \\
-//         \\# the first key
-//         \\key1:
-//         \\  # the first subkey
-//         \\  key1_1: 0
-//         \\  key1_2: 1
-//         \\# the second key
-//         \\key2:
-//         \\  key2_1: -1
-//         \\  key2_2: -2
-//         \\# the end of map
-//     );
-// }
-
-// test "map value indicator needs to be on the same line" {
-//     try parseError(
-//         \\a
-//         \\  : b
-//     , error.UnexpectedToken);
-// }
-
-// test "value needs to be indented" {
-//     try parseError(
-//         \\a:
-//         \\b
-//     , error.MalformedYaml);
-// }
-
-// test "comment between a key and a value is fine" {
-//     try parseSuccess(
-//         \\a:
-//         \\  # this is a value
-//         \\  b
-//     );
-// }
-
-// test "simple list" {
-//     try parseSuccess(
-//         \\# first el
-//         \\- a
-//         \\# second el
-//         \\-  b
-//         \\# third el
-//         \\-   c
-//     );
-// }
-
-// test "list indentation matters" {
-//     try parseError(
-//         \\  - a
-//         \\- b
-//     , error.UnexpectedToken);
-
-//     try parseSuccess(
-//         \\- a
-//         \\  - b
-//     );
-// }
-
-// test "unindented list is fine too" {
-//     try parseSuccess(
-//         \\a:
-//         \\- 0
-//         \\- 1
-//     );
-// }
-
-// test "empty values in a map" {
-//     try parseSuccess(
-//         \\a:
-//         \\b:
-//         \\- 0
-//     );
-// }
-
-// test "weirdly nested map of maps of lists" {
-//     try parseSuccess(
-//         \\a:
-//         \\ b:
-//         \\  - 0
-//         \\  - 1
-//     );
-// }
-
-// test "square brackets denote a list" {
-//     try parseSuccess(
-//         \\[ a,
-//         \\  b, c ]
-//     );
-// }
-
-// test "empty list" {
-//     try parseSuccess(
-//         \\[ ]
-//     );
-// }
-
-// test "empty map" {
-//     try parseSuccess(
-//         \\a:
-//         \\  b: {}
-//         \\  c: { }
-//     );
-// }
-
-// test "comment within a bracketed list is an error" {
-//     try parseError(
-//         \\[ # something
-//         \\]
-//     , error.MalformedYaml);
-// }
-
-// test "mixed ints with floats in a list" {
-//     try parseSuccess(
-//         \\[0, 1.0]
-//     );
-// }
+test "map of list of values" {
+    const source =
+        \\ints:
+        \\  - 0
+        \\  - 1
+        \\  - 2
+    ;
+
+    var parser: Parser = .{ .allocator = testing.allocator, .source = source };
+    defer parser.deinit();
+    try parser.parse();
+
+    var tree = try parser.toOwnedTree();
+    defer tree.deinit(testing.allocator);
+
+    try testing.expectEqual(1, tree.docs.len);
+
+    const doc = tree.docs[0];
+    try expectNodeScope(parser, doc, 0, tree.tokens.len - 2);
+
+    const doc_value = tree.nodeData(doc).value;
+    try testing.expect(doc_value != .none);
+    try testing.expectEqual(.map, tree.nodeTag(doc_value.unwrap().?));
+
+    const map = doc_value.unwrap().?;
+
+    try expectNodeScope(parser, map, 0, tree.tokens.len - 2);
+
+    const map_data = tree.extraData(parse.Map, tree.nodeData(map).extra);
+    try testing.expectEqual(1, map_data.data.map_len);
+
+    const entry_data = tree.extraData(parse.Map.Entry, map_data.end);
+    {
+        const key = tree.getToken(entry_data.data.key);
+        try testing.expectEqual(key.id, .literal);
+        try testing.expectEqualStrings("ints", tree.getRaw(entry_data.data.key, entry_data.data.key));
+
+        const maybe_nested_list = entry_data.data.value;
+        try testing.expect(maybe_nested_list != .none);
+        try testing.expectEqual(.list, tree.nodeTag(maybe_nested_list.unwrap().?));
+
+        const nested_list = maybe_nested_list.unwrap().?;
+
+        try expectNodeScope(parser, nested_list, 4, tree.tokens.len - 2);
+
+        const nested_list_data = tree.extraData(parse.List, tree.nodeData(nested_list).extra);
+        try testing.expectEqual(3, nested_list_data.data.list_len);
+
+        var nested_entry_data = tree.extraData(parse.List.Entry, nested_list_data.end);
+        try expectValueListEntry(tree, nested_entry_data.data, "0");
+
+        nested_entry_data = tree.extraData(parse.List.Entry, nested_entry_data.end);
+        try expectValueListEntry(tree, nested_entry_data.data, "1");
+
+        nested_entry_data = tree.extraData(parse.List.Entry, nested_entry_data.end);
+        try expectValueListEntry(tree, nested_entry_data.data, "2");
+    }
+}
+
+test "map of list of maps" {
+    const source =
+        \\key1:
+        \\- key2 : value2
+        \\- key3 : value3
+        \\- key4 : value4
+    ;
+
+    var parser: Parser = .{ .allocator = testing.allocator, .source = source };
+    defer parser.deinit();
+    try parser.parse();
+
+    var tree = try parser.toOwnedTree();
+    defer tree.deinit(testing.allocator);
+
+    try testing.expectEqual(1, tree.docs.len);
+
+    const doc = tree.docs[0];
+    try expectNodeScope(parser, doc, 0, tree.tokens.len - 2);
+
+    const doc_value = tree.nodeData(doc).value;
+    try testing.expect(doc_value != .none);
+    try testing.expectEqual(.map, tree.nodeTag(doc_value.unwrap().?));
+
+    const map = doc_value.unwrap().?;
+
+    try expectNodeScope(parser, map, 0, tree.tokens.len - 2);
+
+    const map_data = tree.extraData(parse.Map, tree.nodeData(map).extra);
+    try testing.expectEqual(1, map_data.data.map_len);
+
+    const entry_data = tree.extraData(parse.Map.Entry, map_data.end);
+    {
+        const key = tree.getToken(entry_data.data.key);
+        try testing.expectEqual(key.id, .literal);
+        try testing.expectEqualStrings("key1", tree.getRaw(entry_data.data.key, entry_data.data.key));
+
+        const maybe_nested_list = entry_data.data.value;
+        try testing.expect(maybe_nested_list != .none);
+        try testing.expectEqual(.list, tree.nodeTag(maybe_nested_list.unwrap().?));
+
+        const nested_list = maybe_nested_list.unwrap().?;
+
+        try expectNodeScope(parser, nested_list, 3, tree.tokens.len - 2);
+
+        const nested_list_data = tree.extraData(parse.List, tree.nodeData(nested_list).extra);
+        try testing.expectEqual(3, nested_list_data.data.list_len);
+
+        var nested_entry_data = tree.extraData(parse.List.Entry, nested_list_data.end);
+        try expectNestedMapListEntry(tree, nested_entry_data.data, "key2", "value2");
+
+        nested_entry_data = tree.extraData(parse.List.Entry, nested_entry_data.end);
+        try expectNestedMapListEntry(tree, nested_entry_data.data, "key3", "value3");
+
+        nested_entry_data = tree.extraData(parse.List.Entry, nested_entry_data.end);
+        try expectNestedMapListEntry(tree, nested_entry_data.data, "key4", "value4");
+    }
+}
+
+test "map of list of maps with inner list" {
+    const source =
+        \\ outer:
+        \\   - a: foo
+        \\     fooers:
+        \\       - name: inner-foo
+        \\   - b: bar
+        \\     fooers:
+        \\       - name: inner-bar
+    ;
+
+    var parser: Parser = .{ .allocator = testing.allocator, .source = source };
+    defer parser.deinit();
+    try parser.parse();
+
+    var tree = try parser.toOwnedTree();
+    defer tree.deinit(testing.allocator);
+
+    try testing.expectEqual(1, tree.docs.len);
+
+    const doc = tree.docs[0];
+    try expectNodeScope(parser, doc, 1, tree.tokens.len - 2);
+
+    const doc_value = tree.nodeData(doc).value;
+    try testing.expect(doc_value != .none);
+    try testing.expectEqual(.map, tree.nodeTag(doc_value.unwrap().?));
+
+    const map = doc_value.unwrap().?;
+
+    try expectNodeScope(parser, map, 1, tree.tokens.len - 2);
+
+    const map_data = tree.extraData(parse.Map, tree.nodeData(map).extra);
+    try testing.expectEqual(1, map_data.data.map_len);
+
+    const entry_data = tree.extraData(parse.Map.Entry, map_data.end);
+    {
+        const key = tree.getToken(entry_data.data.key);
+        try testing.expectEqual(key.id, .literal);
+        try testing.expectEqualStrings("outer", tree.getRaw(entry_data.data.key, entry_data.data.key));
+
+        const maybe_nested_list = entry_data.data.value;
+        try testing.expect(maybe_nested_list != .none);
+        try testing.expectEqual(.list, tree.nodeTag(maybe_nested_list.unwrap().?));
+
+        const nested_list = maybe_nested_list.unwrap().?;
+
+        try expectNodeScope(parser, nested_list, 5, tree.tokens.len - 2);
+
+        const nested_list_data = tree.extraData(parse.List, tree.nodeData(nested_list).extra);
+        try testing.expectEqual(2, nested_list_data.data.list_len);
+
+        var nested_entry_data = tree.extraData(parse.List.Entry, nested_list_data.end);
+        {
+            const nested_map = nested_entry_data.data.value;
+            try testing.expectEqual(.map, tree.nodeTag(nested_map));
+
+            const nested_map_data = tree.extraData(parse.Map, tree.nodeData(nested_map).extra);
+            try testing.expectEqual(2, nested_map_data.data.map_len);
+
+            var nested_nested_entry_data = tree.extraData(parse.Map.Entry, nested_map_data.end);
+            try expectValueMapEntry(tree, nested_nested_entry_data.data, "a", "foo");
+
+            nested_nested_entry_data = tree.extraData(parse.Map.Entry, nested_nested_entry_data.end);
+            {
+                const nested_nested_map_entry = nested_nested_entry_data.data;
+                const nested_nested_key = tree.getToken(nested_nested_map_entry.key);
+                try testing.expectEqual(nested_nested_key.id, .literal);
+                try testing.expectEqualStrings("fooers", tree.getRaw(nested_nested_map_entry.key, nested_nested_map_entry.key));
+
+                const nested_nested_value = nested_nested_map_entry.value;
+                try testing.expect(nested_nested_value != .none);
+                try testing.expectEqual(.list, tree.nodeTag(nested_nested_value.unwrap().?));
+
+                const nested_nested_list = nested_nested_value.unwrap().?;
+
+                const nested_nested_list_data = tree.extraData(parse.List, tree.nodeData(nested_nested_list).extra);
+                try testing.expectEqual(1, nested_nested_list_data.data.list_len);
+
+                const nested_nested_list_entry_data = tree.extraData(parse.List.Entry, nested_nested_list_data.end);
+                try expectNestedMapListEntry(tree, nested_nested_list_entry_data.data, "name", "inner-foo");
+            }
+        }
+
+        nested_entry_data = tree.extraData(parse.List.Entry, nested_entry_data.end);
+        {
+            const nested_map = nested_entry_data.data.value;
+            try testing.expectEqual(.map, tree.nodeTag(nested_map));
+
+            const nested_map_data = tree.extraData(parse.Map, tree.nodeData(nested_map).extra);
+            try testing.expectEqual(2, nested_map_data.data.map_len);
+
+            var nested_nested_entry_data = tree.extraData(parse.Map.Entry, nested_map_data.end);
+            try expectValueMapEntry(tree, nested_nested_entry_data.data, "b", "bar");
+
+            nested_nested_entry_data = tree.extraData(parse.Map.Entry, nested_nested_entry_data.end);
+            {
+                const nested_nested_map_entry = nested_nested_entry_data.data;
+                const nested_nested_key = tree.getToken(nested_nested_map_entry.key);
+                try testing.expectEqual(nested_nested_key.id, .literal);
+                try testing.expectEqualStrings("fooers", tree.getRaw(nested_nested_map_entry.key, nested_nested_map_entry.key));
+
+                const nested_nested_value = nested_nested_map_entry.value;
+                try testing.expect(nested_nested_value != .none);
+                try testing.expectEqual(.list, tree.nodeTag(nested_nested_value.unwrap().?));
+
+                const nested_nested_list = nested_nested_value.unwrap().?;
+
+                const nested_nested_list_data = tree.extraData(parse.List, tree.nodeData(nested_nested_list).extra);
+                try testing.expectEqual(1, nested_nested_list_data.data.list_len);
+
+                const nested_nested_list_entry_data = tree.extraData(parse.List.Entry, nested_nested_list_data.end);
+                try expectNestedMapListEntry(tree, nested_nested_list_entry_data.data, "name", "inner-bar");
+            }
+        }
+    }
+}
+
+test "list of lists" {
+    const source =
+        \\- [name        , hr, avg  ]
+        \\- [Mark McGwire , 65, 0.278]
+        \\- [Sammy Sosa   , 63, 0.288]
+    ;
+
+    var parser: Parser = .{ .allocator = testing.allocator, .source = source };
+    defer parser.deinit();
+    try parser.parse();
+
+    var tree = try parser.toOwnedTree();
+    defer tree.deinit(testing.allocator);
+
+    try testing.expectEqual(1, tree.docs.len);
+
+    const doc = tree.docs[0];
+    try expectNodeScope(parser, doc, 0, tree.tokens.len - 2);
+
+    const doc_value = tree.nodeData(doc).value;
+    try testing.expect(doc_value != .none);
+    try testing.expectEqual(.list, tree.nodeTag(doc_value.unwrap().?));
+
+    const list = doc_value.unwrap().?;
+
+    try expectNodeScope(parser, list, 0, tree.tokens.len - 2);
+
+    const list_data = tree.extraData(parse.List, tree.nodeData(list).extra);
+    try testing.expectEqual(3, list_data.data.list_len);
+
+    var entry_data = tree.extraData(parse.List.Entry, list_data.end);
+    {
+        const nested_list = entry_data.data.value;
+
+        try expectNodeScope(parser, nested_list, 1, 11);
+
+        const nested_list_data = tree.extraData(parse.List, tree.nodeData(nested_list).extra);
+        try testing.expectEqual(3, nested_list_data.data.list_len);
+
+        var nested_entry_data = tree.extraData(parse.List.Entry, nested_list_data.end);
+        try expectValueListEntry(tree, nested_entry_data.data, "name");
+
+        nested_entry_data = tree.extraData(parse.List.Entry, nested_entry_data.end);
+        try expectValueListEntry(tree, nested_entry_data.data, "hr");
+
+        nested_entry_data = tree.extraData(parse.List.Entry, nested_entry_data.end);
+        try expectValueListEntry(tree, nested_entry_data.data, "avg");
+    }
+
+    entry_data = tree.extraData(parse.List.Entry, entry_data.end);
+    {
+        const nested_list = entry_data.data.value;
+
+        try expectNodeScope(parser, nested_list, 14, 25);
+
+        const nested_list_data = tree.extraData(parse.List, tree.nodeData(nested_list).extra);
+        try testing.expectEqual(3, nested_list_data.data.list_len);
+
+        var nested_entry_data = tree.extraData(parse.List.Entry, nested_list_data.end);
+        try expectValueListEntry(tree, nested_entry_data.data, "Mark McGwire");
+
+        nested_entry_data = tree.extraData(parse.List.Entry, nested_entry_data.end);
+        try expectValueListEntry(tree, nested_entry_data.data, "65");
+
+        nested_entry_data = tree.extraData(parse.List.Entry, nested_entry_data.end);
+        try expectValueListEntry(tree, nested_entry_data.data, "0.278");
+    }
+
+    entry_data = tree.extraData(parse.List.Entry, entry_data.end);
+    {
+        const nested_list = entry_data.data.value;
+
+        try expectNodeScope(parser, nested_list, 28, 39);
+
+        const nested_list_data = tree.extraData(parse.List, tree.nodeData(nested_list).extra);
+        try testing.expectEqual(3, nested_list_data.data.list_len);
+
+        var nested_entry_data = tree.extraData(parse.List.Entry, nested_list_data.end);
+        try expectValueListEntry(tree, nested_entry_data.data, "Sammy Sosa");
+
+        nested_entry_data = tree.extraData(parse.List.Entry, nested_entry_data.end);
+        try expectValueListEntry(tree, nested_entry_data.data, "63");
+
+        nested_entry_data = tree.extraData(parse.List.Entry, nested_entry_data.end);
+        try expectValueListEntry(tree, nested_entry_data.data, "0.288");
+    }
+}
+
+test "inline list" {
+    const source =
+        \\[name        , hr, avg  ]
+    ;
+
+    var parser: Parser = .{ .allocator = testing.allocator, .source = source };
+    defer parser.deinit();
+    try parser.parse();
+
+    var tree = try parser.toOwnedTree();
+    defer tree.deinit(testing.allocator);
+
+    try testing.expectEqual(1, tree.docs.len);
+
+    const doc = tree.docs[0];
+    try expectNodeScope(parser, doc, 0, tree.tokens.len - 2);
+
+    const doc_value = tree.nodeData(doc).value;
+    try testing.expect(doc_value != .none);
+    try testing.expectEqual(.list, tree.nodeTag(doc_value.unwrap().?));
+
+    const list = doc_value.unwrap().?;
+
+    try expectNodeScope(parser, list, 0, tree.tokens.len - 2);
+
+    const list_data = tree.extraData(parse.List, tree.nodeData(list).extra);
+    try testing.expectEqual(3, list_data.data.list_len);
+
+    var entry_data = tree.extraData(parse.List.Entry, list_data.end);
+    try expectValueListEntry(tree, entry_data.data, "name");
+
+    entry_data = tree.extraData(parse.List.Entry, entry_data.end);
+    try expectValueListEntry(tree, entry_data.data, "hr");
+
+    entry_data = tree.extraData(parse.List.Entry, entry_data.end);
+    try expectValueListEntry(tree, entry_data.data, "avg");
+}
+
+test "inline list as mapping value" {
+    const source =
+        \\key : [
+        \\        name        ,
+        \\        hr, avg  ]
+    ;
+
+    var parser: Parser = .{ .allocator = testing.allocator, .source = source };
+    defer parser.deinit();
+    try parser.parse();
+
+    var tree = try parser.toOwnedTree();
+    defer tree.deinit(testing.allocator);
+
+    try testing.expectEqual(1, tree.docs.len);
+
+    const doc = tree.docs[0];
+    try expectNodeScope(parser, doc, 0, tree.tokens.len - 2);
+
+    const doc_value = tree.nodeData(doc).value;
+    try testing.expect(doc_value != .none);
+    try testing.expectEqual(.map, tree.nodeTag(doc_value.unwrap().?));
+
+    const map = doc_value.unwrap().?;
+
+    try expectNodeScope(parser, map, 0, tree.tokens.len - 2);
+
+    const map_data = tree.extraData(parse.Map, tree.nodeData(map).extra);
+    try testing.expectEqual(1, map_data.data.map_len);
+
+    const entry_data = tree.extraData(parse.Map.Entry, map_data.end);
+    {
+        const key = tree.getToken(entry_data.data.key);
+        try testing.expectEqual(key.id, .literal);
+        try testing.expectEqualStrings("key", tree.getRaw(entry_data.data.key, entry_data.data.key));
+
+        const maybe_nested_list = entry_data.data.value;
+        try testing.expect(maybe_nested_list != .none);
+        try testing.expectEqual(.list, tree.nodeTag(maybe_nested_list.unwrap().?));
+
+        const nested_list = maybe_nested_list.unwrap().?;
+
+        try expectNodeScope(parser, nested_list, 4, tree.tokens.len - 2);
+
+        const nested_list_data = tree.extraData(parse.List, tree.nodeData(nested_list).extra);
+        try testing.expectEqual(3, nested_list_data.data.list_len);
+
+        var nested_entry_data = tree.extraData(parse.List.Entry, nested_list_data.end);
+        try expectValueListEntry(tree, nested_entry_data.data, "name");
+
+        nested_entry_data = tree.extraData(parse.List.Entry, nested_entry_data.end);
+        try expectValueListEntry(tree, nested_entry_data.data, "hr");
+
+        nested_entry_data = tree.extraData(parse.List.Entry, nested_entry_data.end);
+        try expectValueListEntry(tree, nested_entry_data.data, "avg");
+    }
+}
+
+fn parseSuccess(comptime source: []const u8) !void {
+    var parser: Parser = .{ .allocator = testing.allocator, .source = source };
+    defer parser.deinit();
+    try parser.parse();
+}
+
+fn parseError(comptime source: []const u8, err: parse.ParseError) !void {
+    var parser: Parser = .{ .allocator = testing.allocator, .source = source };
+    defer parser.deinit();
+    try testing.expectError(err, parser.parse());
+}
+
+test "empty doc with spaces and comments" {
+    try parseSuccess(
+        \\
+        \\
+        \\   # this is a comment in a weird place
+        \\# and this one is too
+    );
+}
+
+test "comment between --- and ! in document start" {
+    try parseError(
+        \\--- # what is it?
+        \\!
+    , error.UnexpectedToken);
+}
+
+test "correct doc start with tag" {
+    try parseSuccess(
+        \\--- !some-tag
+        \\
+    );
+}
+
+test "doc close without explicit doc open" {
+    try parseError(
+        \\
+        \\
+        \\# something cool
+        \\...
+    , error.UnexpectedToken);
+}
+
+test "doc open and close are ok" {
+    try parseSuccess(
+        \\---
+        \\# first doc
+        \\
+        \\
+        \\---
+        \\# second doc
+        \\
+        \\
+        \\...
+    );
+}
+
+test "doc with a single string is ok" {
+    try parseSuccess(
+        \\a string of some sort
+        \\
+    );
+}
+
+test "explicit doc with a single string is ok" {
+    try parseSuccess(
+        \\--- !anchor
+        \\# nothing to see here except one string
+        \\  # not a lot to go on with
+        \\a single string
+        \\...
+    );
+}
+
+test "doc with two string is bad" {
+    try parseError(
+        \\first
+        \\second
+        \\# this should fail already
+    , error.UnexpectedToken);
+}
+
+test "single quote string can have new lines" {
+    try parseSuccess(
+        \\'what is this
+        \\ thing?'
+    );
+}
+
+test "single quote string on one line is fine" {
+    try parseSuccess(
+        \\'here''s an apostrophe'
+    );
+}
+
+test "double quote string can have new lines" {
+    try parseSuccess(
+        \\"what is this
+        \\ thing?"
+    );
+}
+
+test "double quote string on one line is fine" {
+    try parseSuccess(
+        \\"a newline\nand a\ttab"
+    );
+}
+
+test "map with key and value literals" {
+    try parseSuccess(
+        \\key1: val1
+        \\key2 : val2
+    );
+}
+
+test "map of maps" {
+    try parseSuccess(
+        \\
+        \\# the first key
+        \\key1:
+        \\  # the first subkey
+        \\  key1_1: 0
+        \\  key1_2: 1
+        \\# the second key
+        \\key2:
+        \\  key2_1: -1
+        \\  key2_2: -2
+        \\# the end of map
+    );
+}
+
+test "map value indicator needs to be on the same line" {
+    try parseError(
+        \\a
+        \\  : b
+    , error.UnexpectedToken);
+}
+
+test "value needs to be indented" {
+    try parseError(
+        \\a:
+        \\b
+    , error.MalformedYaml);
+}
+
+test "comment between a key and a value is fine" {
+    try parseSuccess(
+        \\a:
+        \\  # this is a value
+        \\  b
+    );
+}
+
+test "simple list" {
+    try parseSuccess(
+        \\# first el
+        \\- a
+        \\# second el
+        \\-  b
+        \\# third el
+        \\-   c
+    );
+}
+
+test "list indentation matters" {
+    try parseError(
+        \\  - a
+        \\- b
+    , error.UnexpectedToken);
+
+    try parseSuccess(
+        \\- a
+        \\  - b
+    );
+}
+
+test "unindented list is fine too" {
+    try parseSuccess(
+        \\a:
+        \\- 0
+        \\- 1
+    );
+}
+
+test "empty values in a map" {
+    try parseSuccess(
+        \\a:
+        \\b:
+        \\- 0
+    );
+}
+
+test "weirdly nested map of maps of lists" {
+    try parseSuccess(
+        \\a:
+        \\ b:
+        \\  - 0
+        \\  - 1
+    );
+}
+
+test "square brackets denote a list" {
+    try parseSuccess(
+        \\[ a,
+        \\  b, c ]
+    );
+}
+
+test "empty list" {
+    try parseSuccess(
+        \\[ ]
+    );
+}
+
+test "empty map" {
+    try parseSuccess(
+        \\a:
+        \\  b: {}
+        \\  c: { }
+    );
+}
+
+test "comment within a bracketed list is an error" {
+    try parseError(
+        \\[ # something
+        \\]
+    , error.MalformedYaml);
+}
+
+test "mixed ints with floats in a list" {
+    try parseSuccess(
+        \\[0, 1.0]
+    );
+}

--- a/src/yaml.zig
+++ b/src/yaml.zig
@@ -158,13 +158,13 @@ pub const Value = union(enum) {
         const tag = tree.nodeTag(node_index);
         switch (tag) {
             .doc => {
-                const inner = tree.nodeData(node_index).maybe_value.unwrap() orelse
+                const inner = tree.nodeData(node_index).maybe_node.unwrap() orelse
                     // empty doc
                     return Value{ .empty = {} };
                 return Value.fromNode(arena, tree, inner);
             },
             .doc_with_directive => {
-                const inner = tree.nodeData(node_index).doc_with_directive.value.unwrap() orelse
+                const inner = tree.nodeData(node_index).doc_with_directive.maybe_node.unwrap() orelse
                     // empty doc
                     return Value{ .empty = {} };
                 return Value.fromNode(arena, tree, inner);
@@ -182,7 +182,7 @@ pub const Value = union(enum) {
                 if (gop.found_existing) {
                     return error.DuplicateMapKey;
                 }
-                const value = if (entry.value.unwrap()) |value|
+                const value = if (entry.maybe_node.unwrap()) |value|
                     try Value.fromNode(arena, tree, value)
                 else
                     .empty;
@@ -209,7 +209,7 @@ pub const Value = union(enum) {
                     if (gop.found_existing) {
                         return error.DuplicateMapKey;
                     }
-                    const value = if (entry.data.value.unwrap()) |value|
+                    const value = if (entry.data.maybe_node.unwrap()) |value|
                         try Value.fromNode(arena, tree, value)
                     else
                         .empty;
@@ -222,7 +222,7 @@ pub const Value = union(enum) {
                 return Value{ .list = &.{} };
             },
             .list_one => {
-                const value_index = tree.nodeData(node_index).value;
+                const value_index = tree.nodeData(node_index).node;
 
                 var out_list = std.ArrayList(Value).init(arena);
                 try out_list.ensureTotalCapacityPrecise(1);
@@ -257,7 +257,7 @@ pub const Value = union(enum) {
                     const elem = tree.extraData(parse_util.List.Entry, extra_end);
                     extra_end = elem.end;
 
-                    const value = try Value.fromNode(arena, tree, elem.data.value);
+                    const value = try Value.fromNode(arena, tree, elem.data.node);
                     out_list.appendAssumeCapacity(value);
                 }
 

--- a/src/yaml.zig
+++ b/src/yaml.zig
@@ -177,7 +177,7 @@ pub const Value = union(enum) {
                 var out_map = std.StringArrayHashMap(Value).init(arena);
                 try out_map.ensureTotalCapacity(1);
 
-                const key = try arena.dupe(u8, tree.getRaw(entry.key, entry.key));
+                const key = try arena.dupe(u8, tree.rawString(entry.key, entry.key));
                 const gop = out_map.getOrPutAssumeCapacity(key);
                 if (gop.found_existing) {
                     return error.DuplicateMapKey;
@@ -204,7 +204,7 @@ pub const Value = union(enum) {
                     const entry = tree.extraData(parse_util.Map.Entry, extra_end);
                     extra_end = entry.end;
 
-                    const key = try arena.dupe(u8, tree.getRaw(entry.data.key, entry.data.key));
+                    const key = try arena.dupe(u8, tree.rawString(entry.data.key, entry.data.key));
                     const gop = out_map.getOrPutAssumeCapacity(key);
                     if (gop.found_existing) {
                         return error.DuplicateMapKey;
@@ -267,7 +267,7 @@ pub const Value = union(enum) {
                 const raw = raw: switch (tag) {
                     .value => {
                         const scope = tree.nodeScope(node_index);
-                        break :raw tree.getRaw(scope.start, scope.end);
+                        break :raw tree.rawString(scope.start, scope.end);
                     },
                     .string_value => {
                         const string = tree.nodeData(node_index).string;
@@ -595,7 +595,7 @@ pub const Yaml = struct {
     pub fn stringify(self: Yaml, writer: anytype) !void {
         for (self.docs.items, self.tree.docs) |doc, node| {
             try writer.writeAll("---");
-            if (self.tree.getDirective(node)) |directive| {
+            if (self.tree.directive(node)) |directive| {
                 try writer.print(" !{s}", .{directive});
             }
             try writer.writeByte('\n');

--- a/src/yaml.zig
+++ b/src/yaml.zig
@@ -12,6 +12,7 @@ pub const parse_util = @import("parse.zig");
 
 const Node = parse_util.Node;
 const Tree = parse_util.Tree;
+const Parser = parse_util.Parser;
 const ParseError = parse_util.ParseError;
 const supportedTruthyBooleanValue: [4][]const u8 = .{ "y", "yes", "on", "true" };
 const supportedFalsyBooleanValue: [4][]const u8 = .{ "n", "no", "off", "false" };
@@ -354,7 +355,12 @@ pub const Yaml = struct {
         var arena = ArenaAllocator.init(allocator);
         errdefer arena.deinit();
 
-        const tree = try parse_util.parse(arena.allocator(), source);
+        var parser: Parser = .{ .allocator = arena.allocator(), .source = source };
+        defer parser.deinit();
+        try parser.parse();
+
+        var tree = try parser.toOwnedTree();
+        errdefer tree.deinit(arena.allocator());
 
         var docs = std.ArrayList(Value).init(arena.allocator());
         try docs.ensureTotalCapacityPrecise(tree.docs.len);
@@ -556,5 +562,5 @@ pub fn stringify(allocator: Allocator, input: anytype, writer: anytype) Stringif
 test {
     std.testing.refAllDecls(Tokenizer);
     std.testing.refAllDecls(parse_util);
-    _ = @import("yaml/test.zig");
+    // _ = @import("yaml/test.zig");
 }

--- a/src/yaml.zig
+++ b/src/yaml.zig
@@ -207,7 +207,7 @@ pub const Value = union(enum) {
                 var extra_end = list.end;
                 for (0..list.data.list_len) |_| {
                     const elem = tree.extraData(parse_util.List.Entry, extra_end);
-                    extra_end = list.end;
+                    extra_end = elem.end;
 
                     const value = try Value.fromNode(arena, tree, elem.data.value);
                     out_list.appendAssumeCapacity(value);
@@ -562,5 +562,5 @@ pub fn stringify(allocator: Allocator, input: anytype, writer: anytype) Stringif
 test {
     std.testing.refAllDecls(Tokenizer);
     std.testing.refAllDecls(parse_util);
-    // _ = @import("yaml/test.zig");
+    _ = @import("yaml/test.zig");
 }

--- a/src/yaml.zig
+++ b/src/yaml.zig
@@ -263,9 +263,18 @@ pub const Value = union(enum) {
 
                 return Value{ .list = try out_list.toOwnedSlice() };
             },
-            .value => {
-                const string = tree.nodeData(node_index).string;
-                const raw = string.slice(tree);
+            .value, .string_value => {
+                const raw = raw: switch (tag) {
+                    .value => {
+                        const scope = tree.nodeScope(node_index);
+                        break :raw tree.getRaw(scope.start, scope.end);
+                    },
+                    .string_value => {
+                        const string = tree.nodeData(node_index).string;
+                        break :raw string.slice(tree);
+                    },
+                    else => unreachable,
+                };
 
                 try_int: {
                     const int = std.fmt.parseInt(i64, raw, 0) catch break :try_int;

--- a/test/spec.zig
+++ b/test/spec.zig
@@ -125,7 +125,7 @@ fn make(step: *Step, make_options: Step.MakeOptions) !void {
     const writer = output.writer();
     try writer.writeAll(preamble);
 
-    while (testcases.popOrNull()) |kv| {
+    while (testcases.pop()) |kv| {
         emitTest(arena, &output, kv.value) catch |err| switch (err) {
             error.OutOfMemory => @panic("OOM"),
             else => |e| return e,


### PR DESCRIPTION
A very much WIP experiment that if pulled successfully will hopefully reduce memory fragmentation and reduce cache misses, while keeping it type-safe. The type-safety will be achieved thanks to the great "enum-is-int" abstraction, i.e.,

```zig
pub const Index = enum(u32) {
  _,
};
```

This a very widespread pattern used extensively in the Zig compiler, so it only makes sense to embrace it in this codebase too.

TODO:
- [x] get all tests passing again
- [x] provide some benchmarks for before and after

### Benchmarks

In order to benchmark the new approach to managing parser's state, I have used Andrew's excellent measurement tool [poop](https://github.com/andrewrk/poop). I have benchmarked 3 cases: 2 simpler ones that are part of the examples in this repo, namely, [test/single_lib.tbd](https://github.com/kubkon/zig-yaml/blob/main/test/single_lib.tbd) and [test/multi_lib.tbd](https://github.com/kubkon/zig-yaml/blob/main/test/multi_lib.tbd), and a beefier input test file that was synthetically crafted with the help of ChatGPT and then tweaked a little manually weighing approximately 2.5MB.

In all cases, the first benchmark was done by the parser pre-rewrite.

#### test/single_lib.tbd

![image](https://github.com/user-attachments/assets/44f0a131-f2df-4dec-ae00-82be6475ae7e)

#### test/multi_lib.tbd

![image](https://github.com/user-attachments/assets/1fdb6021-c931-4fd1-973a-924ec2602ead)

#### beefy.yaml

![image](https://github.com/user-attachments/assets/4d48e3fe-6242-4d38-8cd0-9846e721c2ad)

It is evident that the DoDified parser performs better than naive OO-like (vtable) approach, especially on larger input files. Memory usage of the parser is still something that needs work as well as how the input files are loaded since for very large input files, memory usage explodes.