### PR TITLE
chore: support updated build.zig.zon (zig 0.14.0 prep)

### DIFF
--- a/build.zig.zon
+++ b/build.zig.zon
@@ -1,6 +1,7 @@
 .{
-    .name = "zig-yaml",
+    .name = .zig_yaml,
     .version = "0.1.0",
+    .fingerprint = 0x225b4a67d67a5d0b, // Changing this has security and trust implications.
     .paths = .{
         "src",
         "test",

--- a/src/Yaml.zig
+++ b/src/Yaml.zig
@@ -539,7 +539,7 @@ pub const Value = union(enum) {
         }
     }
 
-    fn encode(arena: Allocator, input: anytype) YamlError!?Value {
+    pub fn encode(arena: Allocator, input: anytype) YamlError!?Value {
         switch (@typeInfo(@TypeOf(input))) {
             .comptime_int,
             .int,


### PR DESCRIPTION
I updated zig again to latest main and found [this](https://github.com/ziglang/zig/commit/d6a88ed74db270c14c669ab334f3ab715cfd2b76#diff-7e9bb30ed31335940f19e196f799a8966cbbbc5a1bf2804de4d90fc7035b847c) and the [tracking ussue](https://github.com/ziglang/zig/commit/d6a88ed74db270c14c669ab334f3ab715cfd2b76#diff-7e9bb30ed31335940f19e196f799a8966cbbbc5a1bf2804de4d90fc7035b847c) created some new stuff for us to have in build.zig.zon file.

tl;dr zig init now adds the fingerprint which should be generated and not change ever afaik. it also adds minimum zig version but I removed that here (though can ofc add it in if you're so inclined). lastly, the package name is now a enum literal instead. and the newer version of zig was quite upset when these were not present 😁

obviously feel free to disregard, just figured since I had to figure out what was what for my project, figured id share the love and open this!

resolves #65  (maybe? or maybe at least part of it I guess)

edit: realized using this was causing an issue as stringily was using non public `encode` method of Value, so just lumped that in there as well!