### PR TITLE
Jump-start better error reporting

### DIFF
--- a/src/Parser.zig
+++ b/src/Parser.zig
@@ -18,7 +18,6 @@ const String = Tree.String;
 const Parser = @This();
 const Yaml = @import("Yaml.zig");
 
-ctx: *Yaml,
 source: []const u8,
 tokens: std.MultiArrayList(TokenWithLineCol) = .empty,
 token_it: TokenIterator = undefined,
@@ -28,8 +27,8 @@ extra: std.ArrayListUnmanaged(u32) = .empty,
 string_bytes: std.ArrayListUnmanaged(u8) = .empty,
 errors: ErrorBundle.Wip,
 
-pub fn init(gpa: Allocator, source: []const u8, ctx: *Yaml) Allocator.Error!Parser {
-    var self: Parser = .{ .ctx = ctx, .source = source, .errors = undefined };
+pub fn init(gpa: Allocator, source: []const u8) Allocator.Error!Parser {
+    var self: Parser = .{ .source = source, .errors = undefined };
     try self.errors.init(gpa);
     return self;
 }
@@ -729,7 +728,7 @@ fn fail(self: *Parser, gpa: Allocator, token_index: Token.Index, comptime format
     try self.errors.addRootErrorMessage(.{
         .msg = try self.errors.addString(msg),
         .src_loc = try self.errors.addSourceLocation(.{
-            .src_path = try self.errors.addString("(source)"),
+            .src_path = try self.errors.addString("(memory)"),
             .line = line_col.line,
             .column = line_col.col,
             .span_start = line_info.span_start,

--- a/src/Parser.zig
+++ b/src/Parser.zig
@@ -208,7 +208,10 @@ fn doc(self: *Parser, gpa: Allocator) ParseError!Node.Index {
     // Parse footer
     const node_end: Token.Index = footer: {
         if (self.eatToken(.doc_end, &.{})) |pos| {
-            if (!is_explicit) return error.UnexpectedToken;
+            if (!is_explicit) {
+                self.token_it.seekBy(-1);
+                return self.fail(gpa, self.token_it.pos, "missing explicit document open marker '---'", .{});
+            }
             if (self.getCol(pos) > 0) return error.MalformedYaml;
             break :footer pos;
         }

--- a/src/Parser.zig
+++ b/src/Parser.zig
@@ -293,7 +293,7 @@ fn map(self: *Parser, gpa: Allocator) ParseError!Node.OptionalIndex {
             }
             if (self.nodes.items(.tag)[@intFromEnum(v)] == .value) {
                 if (self.getCol(value_start) == self.getCol(key_pos)) {
-                    return error.MalformedYaml;
+                    return self.fail(gpa, value_start, "'value' in map should have more indentation than the 'key'", .{});
                 }
             }
         }

--- a/src/Parser.zig
+++ b/src/Parser.zig
@@ -274,11 +274,7 @@ fn map(self: *Parser, gpa: Allocator) ParseError!Node.OptionalIndex {
             .flow_map_end => {
                 break;
             },
-            else => {
-                log.err("Unhandled token in map: {}", .{key});
-                // TODO key not being a literal
-                return error.Unhandled;
-            },
+            else => return self.fail(gpa, self.token_it.pos, "unexpected token for 'key': {}", .{key}),
         }
 
         log.debug("(map) key {s}@{d}", .{ self.rawString(key_pos, key_pos), key_pos });
@@ -783,7 +779,6 @@ pub const ParseError = error{
     NestedDocuments,
     UnexpectedEof,
     UnexpectedToken,
-    Unhandled,
     ParseFailure,
 } || Allocator.Error;
 

--- a/src/Parser.zig
+++ b/src/Parser.zig
@@ -213,13 +213,7 @@ fn doc(self: *Parser, gpa: Allocator) ParseError!Node.Index {
             break :footer @enumFromInt(@intFromEnum(pos) - 1);
         }
 
-        try self.ctx.fail(
-            gpa,
-            self.tokens.items(.line_col)[@intFromEnum(self.token_it.pos)],
-            "expected end of document",
-            .{},
-        );
-        return error.UnexpectedToken;
+        return self.fail(gpa, self.token_it.pos, "expected end of document", .{});
     };
 
     log.debug("(doc) end {s}@{d}", .{ @tagName(self.token(node_end).id), node_end });
@@ -716,6 +710,16 @@ fn token(self: Parser, index: Token.Index) Token {
     return self.tokens.items(.token)[@intFromEnum(index)];
 }
 
+fn fail(self: Parser, gpa: Allocator, token_index: Token.Index, comptime format: []const u8, args: anytype) ParseError {
+    try self.ctx.fail(
+        gpa,
+        self.tokens.items(.line_col)[@intFromEnum(token_index)],
+        format,
+        args,
+    );
+    return error.ParseFailure;
+}
+
 pub const ParseError = error{
     InvalidEscapeSequence,
     MalformedYaml,
@@ -723,6 +727,7 @@ pub const ParseError = error{
     UnexpectedEof,
     UnexpectedToken,
     Unhandled,
+    ParseFailure,
 } || Allocator.Error;
 
 test {

--- a/src/Parser.zig
+++ b/src/Parser.zig
@@ -36,8 +36,8 @@ pub fn deinit(self: *Parser, gpa: Allocator) void {
 
 pub fn parse(self: *Parser, gpa: Allocator) ParseError!void {
     var tokenizer = Tokenizer{ .buffer = self.source };
-    var line: usize = 0;
-    var prev_line_last_col: usize = 0;
+    var line: u32 = 0;
+    var prev_line_last_col: u32 = 0;
 
     while (true) {
         const tok = tokenizer.next();
@@ -47,7 +47,7 @@ pub fn parse(self: *Parser, gpa: Allocator) ParseError!void {
             .token = tok,
             .line_col = .{
                 .line = line,
-                .col = tok.loc.start - prev_line_last_col,
+                .col = @intCast(tok.loc.start - prev_line_last_col),
             },
         });
 
@@ -55,7 +55,7 @@ pub fn parse(self: *Parser, gpa: Allocator) ParseError!void {
             .eof => break,
             .new_line => {
                 line += 1;
-                prev_line_last_col = tok.loc.end;
+                prev_line_last_col = @intCast(tok.loc.end);
             },
             else => {},
         }
@@ -216,7 +216,7 @@ fn doc(self: *Parser, gpa: Allocator) ParseError!Node.Index {
         try self.ctx.fail(
             gpa,
             self.tokens.items(.line_col)[@intFromEnum(self.token_it.pos)],
-            "expected end of document but found",
+            "expected end of document",
             .{},
         );
         return error.UnexpectedToken;

--- a/src/Parser.zig
+++ b/src/Parser.zig
@@ -14,7 +14,9 @@ const TokenWithLineCol = Tree.TokenWithLineCol;
 const Tree = @import("Tree.zig");
 const String = Tree.String;
 const Parser = @This();
+const Yaml = @import("Yaml.zig");
 
+ctx: *Yaml,
 source: []const u8,
 tokens: std.MultiArrayList(TokenWithLineCol) = .empty,
 token_it: TokenIterator = undefined,
@@ -210,6 +212,13 @@ fn doc(self: *Parser, gpa: Allocator) ParseError!Node.Index {
         if (self.eatToken(.eof, &.{})) |pos| {
             break :footer @enumFromInt(@intFromEnum(pos) - 1);
         }
+
+        try self.ctx.fail(
+            gpa,
+            self.tokens.items(.line_col)[@intFromEnum(self.token_it.pos)],
+            "expected end of document but found",
+            .{},
+        );
         return error.UnexpectedToken;
     };
 

--- a/src/Parser.zig
+++ b/src/Parser.zig
@@ -275,7 +275,8 @@ fn map(self: *Parser, gpa: Allocator) ParseError!Node.OptionalIndex {
         log.debug("(map) key {s}@{d}", .{ self.rawString(key_pos, key_pos), key_pos });
 
         // Separator
-        _ = try self.expectToken(.map_value_ind, &.{ .new_line, .comment });
+        _ = self.expectToken(.map_value_ind, &.{ .new_line, .comment }) catch
+            return self.fail(gpa, self.token_it.pos, "expected map separator ':'", .{});
 
         // Parse value
         const value_index = try self.value(gpa);

--- a/src/Parser/test.zig
+++ b/src/Parser/test.zig
@@ -780,10 +780,15 @@ test "map value indicator needs to be on the same line" {
 }
 
 test "value needs to be indented" {
-    try parseError(
+    try parseError2(
         \\a:
         \\b
-    , error.MalformedYaml);
+    ,
+        \\(memory):2:1: error: 'value' in map should have more indentation than the 'key'
+        \\b
+        \\^
+        \\
+    , .{});
 }
 
 test "comment between a key and a value is fine" {

--- a/src/Parser/test.zig
+++ b/src/Parser/test.zig
@@ -666,12 +666,17 @@ test "correct doc start with tag" {
 }
 
 test "doc close without explicit doc open" {
-    try parseError(
+    try parseError2(
         \\
         \\
         \\# something cool
         \\...
-    , error.UnexpectedToken);
+    ,
+        \\(memory):4:1: error: missing explicit document open marker '---'
+        \\...
+        \\^~~
+        \\
+    , .{});
 }
 
 test "doc open and close are ok" {

--- a/src/Tree.zig
+++ b/src/Tree.zig
@@ -241,8 +241,8 @@ pub const String = struct {
 
 /// Tracked line-column information for each Token.
 pub const LineCol = struct {
-    line: usize,
-    col: usize,
+    line: u32,
+    col: u32,
 };
 
 /// Token with line-column information.

--- a/src/Yaml.zig
+++ b/src/Yaml.zig
@@ -271,9 +271,8 @@ fn getLineInfo(self: Yaml, line_col: Tree.LineCol) struct {
     };
 
     const span_start: u32 = span_start: {
-        var begin: usize = 0;
-        while (begin < line.len and mem.indexOfScalar(u8, " ", line[begin]) != null) : (begin += 1) {}
-        break :span_start @intCast(begin);
+        const trimmed = mem.trimLeft(u8, line, " ");
+        break :span_start @intCast(mem.indexOf(u8, line, trimmed).?);
     };
 
     const span_end: u32 = @intCast(mem.trimRight(u8, line, " \r\n").len);

--- a/src/Yaml.zig
+++ b/src/Yaml.zig
@@ -33,7 +33,7 @@ pub fn deinit(self: *Yaml, gpa: Allocator) void {
 }
 
 pub fn load(self: *Yaml, gpa: Allocator) !void {
-    var parser = try Parser.init(gpa, self.source, self);
+    var parser = try Parser.init(gpa, self.source);
     defer parser.deinit(gpa);
 
     parser.parse(gpa) catch |err| switch (err) {

--- a/src/Yaml/test.zig
+++ b/src/Yaml/test.zig
@@ -13,8 +13,9 @@ test "simple list" {
         \\- c
     ;
 
-    var yaml = try Yaml.load(testing.allocator, source);
+    var yaml: Yaml = .{ .source = source };
     defer yaml.deinit(testing.allocator);
+    try yaml.load(testing.allocator);
 
     try testing.expectEqual(yaml.docs.items.len, 1);
 
@@ -33,8 +34,9 @@ test "simple list typed as array of strings" {
         \\- c
     ;
 
-    var yaml = try Yaml.load(testing.allocator, source);
+    var yaml: Yaml = .{ .source = source };
     defer yaml.deinit(testing.allocator);
+    try yaml.load(testing.allocator);
 
     try testing.expectEqual(yaml.docs.items.len, 1);
 
@@ -55,8 +57,9 @@ test "simple list typed as array of ints" {
         \\- 2
     ;
 
-    var yaml = try Yaml.load(testing.allocator, source);
+    var yaml: Yaml = .{ .source = source };
     defer yaml.deinit(testing.allocator);
+    try yaml.load(testing.allocator);
 
     try testing.expectEqual(yaml.docs.items.len, 1);
 
@@ -74,8 +77,9 @@ test "list of mixed sign integer" {
         \\- 2
     ;
 
-    var yaml = try Yaml.load(testing.allocator, source);
+    var yaml: Yaml = .{ .source = source };
     defer yaml.deinit(testing.allocator);
+    try yaml.load(testing.allocator);
 
     try testing.expectEqual(yaml.docs.items.len, 1);
 
@@ -96,8 +100,9 @@ test "several integer bases" {
         \\- -0O10
     ;
 
-    var yaml = try Yaml.load(testing.allocator, source);
+    var yaml: Yaml = .{ .source = source };
     defer yaml.deinit(testing.allocator);
+    try yaml.load(testing.allocator);
 
     try testing.expectEqual(yaml.docs.items.len, 1);
 
@@ -113,8 +118,9 @@ test "simple map untyped" {
         \\a: 0
     ;
 
-    var yaml = try Yaml.load(testing.allocator, source);
+    var yaml: Yaml = .{ .source = source };
     defer yaml.deinit(testing.allocator);
+    try yaml.load(testing.allocator);
 
     try testing.expectEqual(yaml.docs.items.len, 1);
 
@@ -134,8 +140,9 @@ test "simple map untyped with a list of maps" {
         \\c: 1
     ;
 
-    var yaml = try Yaml.load(testing.allocator, source);
+    var yaml: Yaml = .{ .source = source };
     defer yaml.deinit(testing.allocator);
+    try yaml.load(testing.allocator);
 
     try testing.expectEqual(yaml.docs.items.len, 1);
 
@@ -158,8 +165,9 @@ test "simple map untyped with a list of maps. no indent" {
         \\c: 1
     ;
 
-    var yaml = try Yaml.load(testing.allocator, source);
+    var yaml: Yaml = .{ .source = source };
     defer yaml.deinit(testing.allocator);
+    try yaml.load(testing.allocator);
 
     try testing.expectEqual(yaml.docs.items.len, 1);
 
@@ -181,8 +189,9 @@ test "simple map untyped with a list of maps. no indent 2" {
         \\c: 1
     ;
 
-    var yaml = try Yaml.load(testing.allocator, source);
+    var yaml: Yaml = .{ .source = source };
     defer yaml.deinit(testing.allocator);
+    try yaml.load(testing.allocator);
 
     try testing.expectEqual(yaml.docs.items.len, 1);
 
@@ -205,8 +214,9 @@ test "simple map typed" {
         \\c: 'wait, what?'
     ;
 
-    var yaml = try Yaml.load(testing.allocator, source);
+    var yaml: Yaml = .{ .source = source };
     defer yaml.deinit(testing.allocator);
+    try yaml.load(testing.allocator);
 
     var arena = Arena.init(testing.allocator);
     defer arena.deinit();
@@ -224,8 +234,9 @@ test "typed nested structs" {
         \\  c: 'wait, what?'
     ;
 
-    var yaml = try Yaml.load(testing.allocator, source);
+    var yaml: Yaml = .{ .source = source };
     defer yaml.deinit(testing.allocator);
+    try yaml.load(testing.allocator);
 
     var arena = Arena.init(testing.allocator);
     defer arena.deinit();
@@ -246,8 +257,9 @@ test "typed union with nested struct" {
         \\  b: hello there
     ;
 
-    var yaml = try Yaml.load(testing.allocator, source);
+    var yaml: Yaml = .{ .source = source };
     defer yaml.deinit(testing.allocator);
+    try yaml.load(testing.allocator);
 
     var arena = Arena.init(testing.allocator);
     defer arena.deinit();
@@ -273,8 +285,9 @@ test "typed union with nested struct 2" {
         \\  d: hello there
     ;
 
-    var yaml = try Yaml.load(testing.allocator, source);
+    var yaml: Yaml = .{ .source = source };
     defer yaml.deinit(testing.allocator);
+    try yaml.load(testing.allocator);
 
     var arena = Arena.init(testing.allocator);
     defer arena.deinit();
@@ -301,8 +314,9 @@ test "single quoted string" {
         \\- 'newlines and tabs\nare not\tsupported'
     ;
 
-    var yaml = try Yaml.load(testing.allocator, source);
+    var yaml: Yaml = .{ .source = source };
     defer yaml.deinit(testing.allocator);
+    try yaml.load(testing.allocator);
 
     var arena = Arena.init(testing.allocator);
     defer arena.deinit();
@@ -323,8 +337,9 @@ test "double quoted string" {
         \\some fun!"
     ;
 
-    var yaml = try Yaml.load(testing.allocator, source);
+    var yaml: Yaml = .{ .source = source };
     defer yaml.deinit(testing.allocator);
+    try yaml.load(testing.allocator);
 
     var arena = Arena.init(testing.allocator);
     defer arena.deinit();
@@ -351,8 +366,9 @@ test "multidoc typed as a slice of structs" {
         \\...
     ;
 
-    var yaml = try Yaml.load(testing.allocator, source);
+    var yaml: Yaml = .{ .source = source };
     defer yaml.deinit(testing.allocator);
+    try yaml.load(testing.allocator);
 
     var arena = Arena.init(testing.allocator);
     defer arena.deinit();
@@ -381,8 +397,9 @@ test "multidoc typed as a struct is an error" {
         \\...
     ;
 
-    var yaml = try Yaml.load(testing.allocator, source);
+    var yaml: Yaml = .{ .source = source };
     defer yaml.deinit(testing.allocator);
+    try yaml.load(testing.allocator);
 
     var arena = Arena.init(testing.allocator);
     defer arena.deinit();
@@ -403,8 +420,9 @@ test "multidoc typed as a slice of structs with optionals" {
         \\...
     ;
 
-    var yaml = try Yaml.load(testing.allocator, source);
+    var yaml: Yaml = .{ .source = source };
     defer yaml.deinit(testing.allocator);
+    try yaml.load(testing.allocator);
 
     var arena = Arena.init(testing.allocator);
     defer arena.deinit();
@@ -425,8 +443,10 @@ test "multidoc typed as a slice of structs with optionals" {
 
 test "empty yaml can be represented as void" {
     const source = "";
-    var yaml = try Yaml.load(testing.allocator, source);
+
+    var yaml: Yaml = .{ .source = source };
     defer yaml.deinit(testing.allocator);
+    try yaml.load(testing.allocator);
 
     var arena = Arena.init(testing.allocator);
     defer arena.deinit();
@@ -440,8 +460,9 @@ test "nonempty yaml cannot be represented as void" {
         \\a: b
     ;
 
-    var yaml = try Yaml.load(testing.allocator, source);
+    var yaml: Yaml = .{ .source = source };
     defer yaml.deinit(testing.allocator);
+    try yaml.load(testing.allocator);
 
     var arena = Arena.init(testing.allocator);
     defer arena.deinit();
@@ -455,8 +476,9 @@ test "typed array size mismatch" {
         \\- 0
     ;
 
-    var yaml = try Yaml.load(testing.allocator, source);
+    var yaml: Yaml = .{ .source = source };
     defer yaml.deinit(testing.allocator);
+    try yaml.load(testing.allocator);
 
     var arena = Arena.init(testing.allocator);
     defer arena.deinit();
@@ -477,8 +499,9 @@ test "comments" {
         \\- val2
     ;
 
-    var yaml = try Yaml.load(testing.allocator, source);
+    var yaml: Yaml = .{ .source = source };
     defer yaml.deinit(testing.allocator);
+    try yaml.load(testing.allocator);
 
     var arena = Arena.init(testing.allocator);
     defer arena.deinit();
@@ -496,8 +519,9 @@ test "promote ints to floats in a list mixed numeric types" {
         \\a_list: [0, 1.0]
     ;
 
-    var yaml = try Yaml.load(testing.allocator, source);
+    var yaml: Yaml = .{ .source = source };
     defer yaml.deinit(testing.allocator);
+    try yaml.load(testing.allocator);
 
     var arena = Arena.init(testing.allocator);
     defer arena.deinit();
@@ -513,8 +537,9 @@ test "demoting floats to ints in a list is an error" {
         \\a_list: [0, 1.0]
     ;
 
-    var yaml = try Yaml.load(testing.allocator, source);
+    var yaml: Yaml = .{ .source = source };
     defer yaml.deinit(testing.allocator);
+    try yaml.load(testing.allocator);
 
     var arena = Arena.init(testing.allocator);
     defer arena.deinit();
@@ -529,7 +554,9 @@ test "duplicate map keys" {
         \\a: b
         \\a: c
     ;
-    try testing.expectError(error.DuplicateMapKey, Yaml.load(testing.allocator, source));
+    var yaml: Yaml = .{ .source = source };
+    defer yaml.deinit(testing.allocator);
+    try testing.expectError(error.DuplicateMapKey, yaml.load(testing.allocator));
 }
 
 fn testStringify(expected: []const u8, input: anytype) !void {

--- a/test/spec.zig
+++ b/test/spec.zig
@@ -30,7 +30,10 @@ const preamble =
     \\    const source = try file.readToEndAlloc(alloc, std.math.maxInt(u32));
     \\    defer alloc.free(source);
     \\
-    \\    return Yaml.load(alloc, source);
+    \\    var yaml: Yaml = .{ .source = source };
+    \\    errdefer yaml.deinit(alloc);
+    \\    try yaml.load(alloc);
+    \\    return yaml;
     \\}
     \\
     \\fn loadFileString(file_path: []const u8) ![]u8 {

--- a/test/test.zig
+++ b/test/test.zig
@@ -15,7 +15,10 @@ fn loadFromFile(file_path: []const u8) !Yaml {
     const source = try file.readToEndAlloc(gpa, std.math.maxInt(u32));
     defer gpa.free(source);
 
-    return Yaml.load(gpa, source);
+    var yaml: Yaml = .{ .source = source };
+    errdefer yaml.deinit(gpa);
+    try yaml.load(gpa);
+    return yaml;
 }
 
 test "simple" {


### PR DESCRIPTION
This PR overhauls the errors reported by the library. The gist of the changes is that your typical error set is used to signal that an error condition happened, while the actual errors are encoded in a cache-friendly way on the side. For encoding format, I have decided to re-use Zig's very own `std.zig.ErrorBundle` - I think it's a great fit at least in the beginning. That said, I assumed there will be *multiple* errors returned during parsing and/or typing stages which may not be the case due to YAML using whitespace as block markers. Perhaps for multi-document YAMLs that would actually make sense (to be able to report multiple errors and not giving up early).

With these changes, the client code that is embedding this parsing library would access errors like this:

```zig
var yaml: Yaml = .{ .source = source };
defer yaml.deinit(gpa);

yaml.load(gpa) catch |err| switch (err) {
    error.ParseFailure => {
        assert(yaml.parse_errors.errorMessageCount() > 0);
        yaml.parse_errors.renderToStdErr(.{ .ttyconf = std.io.tty.detectConfig(std.io.getStdErr()) });
        return error.ParseFailure;
    },
    else => return err,
};
```

Your typical error would then look as follows:

```yaml
a:
b
```

```
(memory):2:1: error: value 'b' in map should have more indentation than the key 'a'
b
^

```

`(memory)` here refers to the fact that currently the library only accepts YAML as raw string, but the idea will be that it will also operate on `std.fs.FIle`s directly in which case `(memory)` will become the filename.

TODO:
- [x] migrate `Parser` errors to the new scheme - add/fix any relevant tests
- [ ] migrate `Yaml` (typing) errors to the new scheme - add/fix any relevant tests
- [x] document breaking changes in the README

Please note that fixing any parsing/typing logic is out-of-scope of this PR even if it is invalid when compared with YAML parsers out there.

Closes #17 