### PR TITLE
Allow trailing comma in flow sequences / bracket lists

### DIFF
--- a/src/Parser.zig
+++ b/src/Parser.zig
@@ -417,14 +417,15 @@ fn listBracketed(self: *Parser, gpa: Allocator) ParseError!Node.OptionalIndex {
             break pos;
 
         const value_index = try self.value(gpa);
-        if (value_index == .none) return error.MalformedYaml;
+        if (value_index == .none) {
+            return self.fail(gpa, self.token_it.pos, "expecting a value in flow sequence", .{});
+        }
 
         try values.append(gpa, .{ .node = value_index.unwrap().? });
     };
 
     if (self.eatToken(.comment, &.{.comment})) |_| {
-        // There must be a space after the closing bracket before a comment
-        return error.MalformedYaml;
+        return self.fail(gpa, self.token_it.pos, "comments must be separated from other tokens by white space characters", .{});
     }
 
     log.debug("(list) end {s}@{d}", .{ @tagName(self.token(node_end).id), node_end });

--- a/src/Parser.zig
+++ b/src/Parser.zig
@@ -422,6 +422,11 @@ fn listBracketed(self: *Parser, gpa: Allocator) ParseError!Node.OptionalIndex {
         try values.append(gpa, .{ .node = value_index.unwrap().? });
     };
 
+    if (self.eatToken(.comment, &.{.comment})) |_| {
+        // There must be a space after the closing bracket before a comment
+        return error.MalformedYaml;
+    }
+
     log.debug("(list) end {s}@{d}", .{ @tagName(self.token(node_end).id), node_end });
 
     try self.encodeList(gpa, node_index, values.items, .{

--- a/src/Parser.zig
+++ b/src/Parser.zig
@@ -416,16 +416,17 @@ fn listBracketed(self: *Parser, gpa: Allocator) ParseError!Node.OptionalIndex {
         if (self.eatToken(.flow_seq_end, &.{.comment})) |pos|
             break pos;
 
+        const value_raw_pos = self.token_it.pos;
         const value_index = try self.value(gpa);
         if (value_index == .none) {
-            return self.fail(gpa, self.token_it.pos, "expecting a value in flow sequence", .{});
+            return self.fail(gpa, value_raw_pos, "expecting a value in flow sequence", .{});
         }
 
         try values.append(gpa, .{ .node = value_index.unwrap().? });
     };
 
-    if (self.eatToken(.comment, &.{.comment})) |_| {
-        return self.fail(gpa, self.token_it.pos, "comments must be separated from other tokens by white space characters", .{});
+    if (self.eatToken(.comment, &.{.comment})) |pos| {
+        return self.fail(gpa, pos, "comments must be separated from other tokens by white space characters", .{});
     }
 
     log.debug("(list) end {s}@{d}", .{ @tagName(self.token(node_end).id), node_end });

--- a/src/Parser.zig
+++ b/src/Parser.zig
@@ -413,6 +413,9 @@ fn listBracketed(self: *Parser, gpa: Allocator) ParseError!Node.OptionalIndex {
 
         _ = self.eatToken(.comma, &.{.comment});
 
+        if (self.eatToken(.flow_seq_end, &.{.comment})) |pos|
+            break pos;
+
         const value_index = try self.value(gpa);
         if (value_index == .none) return error.MalformedYaml;
 

--- a/src/Parser/test.zig
+++ b/src/Parser/test.zig
@@ -882,7 +882,7 @@ test "comment within a bracketed list is an error" {
     try parseError(
         \\[ # something
         \\]
-    , error.MalformedYaml);
+    , error.ParseFailure);
 }
 
 test "mixed ints with floats in a list" {

--- a/src/Tokenizer.zig
+++ b/src/Tokenizer.zig
@@ -169,6 +169,7 @@ pub fn next(self: *Tokenizer) Token {
                     break;
                 },
                 '#' => {
+                    result.id = .comment;
                     state = .comment;
                 },
                 '*' => {

--- a/src/Yaml/test.zig
+++ b/src/Yaml/test.zig
@@ -164,7 +164,19 @@ test "simple flow sequence / bracket list with invalid comment" {
     defer yaml.deinit(testing.allocator);
     const err = yaml.load(testing.allocator);
 
-    try std.testing.expectError(error.MalformedYaml, err);
+    try std.testing.expectError(error.ParseFailure, err);
+}
+
+test "simple flow sequence / bracket list with double trailing commas" {
+    const source =
+        \\a_key: [a, b, c,,]
+    ;
+
+    var yaml: Yaml = .{ .source = source };
+    defer yaml.deinit(testing.allocator);
+    const err = yaml.load(testing.allocator);
+
+    try std.testing.expectError(error.ParseFailure, err);
 }
 
 test "simple map untyped" {

--- a/src/Yaml/test.zig
+++ b/src/Yaml/test.zig
@@ -129,9 +129,9 @@ test "simple flow sequence / bracket list" {
     const list = map.get("a_key").?.list;
     try testing.expectEqual(list.len, 3);
 
-    try testing.expectEqualStrings("a", list[0].string);
-    try testing.expectEqualStrings("b", list[1].string);
-    try testing.expectEqualStrings("c", list[2].string);
+    try testing.expectEqualStrings("a", list[0].scalar);
+    try testing.expectEqualStrings("b", list[1].scalar);
+    try testing.expectEqualStrings("c", list[2].scalar);
 }
 
 test "simple flow sequence / bracket list with trailing comma" {
@@ -150,9 +150,9 @@ test "simple flow sequence / bracket list with trailing comma" {
     const list = map.get("a_key").?.list;
     try testing.expectEqual(list.len, 3);
 
-    try testing.expectEqualStrings("a", list[0].string);
-    try testing.expectEqualStrings("b", list[1].string);
-    try testing.expectEqualStrings("c", list[2].string);
+    try testing.expectEqualStrings("a", list[0].scalar);
+    try testing.expectEqualStrings("b", list[1].scalar);
+    try testing.expectEqualStrings("c", list[2].scalar);
 }
 
 test "simple flow sequence / bracket list with invalid comment" {

--- a/src/Yaml/test.zig
+++ b/src/Yaml/test.zig
@@ -113,6 +113,48 @@ test "several integer bases" {
     try testing.expectEqualSlices(i8, &[_]i8{ 10, -10, 16, -16, 8, -8 }, &arr);
 }
 
+test "simple flow sequence / bracket list" {
+    const source =
+        \\a_key: [a, b, c]
+    ;
+
+    var yaml: Yaml = .{ .source = source };
+    defer yaml.deinit(testing.allocator);
+    try yaml.load(testing.allocator);
+
+    try testing.expectEqual(yaml.docs.items.len, 1);
+
+    const map = yaml.docs.items[0].map;
+
+    const list = map.get("a_key").?.list;
+    try testing.expectEqual(list.len, 3);
+
+    try testing.expectEqualStrings("a", list[0].string);
+    try testing.expectEqualStrings("b", list[1].string);
+    try testing.expectEqualStrings("c", list[2].string);
+}
+
+test "simple flow sequence / bracket list with trailing comma" {
+    const source =
+        \\a_key: [a, b, c,]
+    ;
+
+    var yaml: Yaml = .{ .source = source };
+    defer yaml.deinit(testing.allocator);
+    try yaml.load(testing.allocator);
+
+    try testing.expectEqual(yaml.docs.items.len, 1);
+
+    const map = yaml.docs.items[0].map;
+
+    const list = map.get("a_key").?.list;
+    try testing.expectEqual(list.len, 3);
+
+    try testing.expectEqualStrings("a", list[0].string);
+    try testing.expectEqualStrings("b", list[1].string);
+    try testing.expectEqualStrings("c", list[2].string);
+}
+
 test "simple map untyped" {
     const source =
         \\a: 0

--- a/src/Yaml/test.zig
+++ b/src/Yaml/test.zig
@@ -155,6 +155,18 @@ test "simple flow sequence / bracket list with trailing comma" {
     try testing.expectEqualStrings("c", list[2].string);
 }
 
+test "simple flow sequence / bracket list with invalid comment" {
+    const source =
+        \\a_key: [a, b, c]#invalid
+    ;
+
+    var yaml: Yaml = .{ .source = source };
+    defer yaml.deinit(testing.allocator);
+    const err = yaml.load(testing.allocator);
+
+    try std.testing.expectError(error.MalformedYaml, err);
+}
+
 test "simple map untyped" {
     const source =
         \\a: 0


### PR DESCRIPTION
A trailing comma is allowed in a flow sequence. See https://yaml.org/spec/1.2.2/#741-flow-sequences 

Currently it will result in a MalformedYaml response. 
This resolves that.