### PR TITLE
Support bools and enums

### DIFF
--- a/src/Yaml.zig
+++ b/src/Yaml.zig
@@ -541,6 +541,10 @@ pub const Value = union(enum) {
             .float,
             => return Value{ .scalar = try std.fmt.allocPrint(arena, "{d}", .{input}) },
 
+            // TODO - Support per-field option to use yes/no or on/off instead of true/false
+            .bool,
+            => return Value{ .scalar = try std.fmt.allocPrint(arena, "{}", .{input}) },
+
             .@"struct" => |info| if (info.is_tuple) {
                 var list: std.ArrayListUnmanaged(Value) = .empty;
                 try list.ensureTotalCapacityPrecise(arena, info.fields.len);
@@ -617,7 +621,6 @@ pub const Value = union(enum) {
             .optional => return if (input) |val| encode(arena, val) else null,
 
             .null => return null,
-            .bool => return Value{ .boolean = input },
 
             else => {
                 @compileError("Unhandled type: " ++ @typeName(@TypeOf(input)));

--- a/src/Yaml/test.zig
+++ b/src/Yaml/test.zig
@@ -179,6 +179,31 @@ test "simple flow sequence / bracket list with double trailing commas" {
     try std.testing.expectError(error.ParseFailure, err);
 }
 
+test "bools" {
+    const source =
+        \\- false
+        \\- true
+        \\- off
+        \\- on
+        \\- no
+        \\- yes
+        \\- n
+        \\- y
+    ;
+
+    var yaml: Yaml = .{ .source = source };
+    defer yaml.deinit(testing.allocator);
+    try yaml.load(testing.allocator);
+
+    try testing.expectEqual(yaml.docs.items.len, 1);
+
+    var arena = Arena.init(testing.allocator);
+    defer arena.deinit();
+
+    const arr = try yaml.parse(arena.allocator(), [8]bool);
+    try testing.expectEqualSlices(bool, &[_]bool{ false, true, false, true, false, true, false, true, }, &arr);
+}
+
 const TestEnum = enum {
     alpha,
     bravo,
@@ -826,6 +851,11 @@ test "struct default value test" {
         try testing.expectEqual(tc.container.c, parsed.c);
         try testing.expectEqual(tc.container.d, parsed.d);
     }
+}
+
+test "stringify a bool" {
+    try testStringify("false", false);
+    try testStringify("true", true);
 }
 
 test "stringify an enum" {


### PR DESCRIPTION
Fix errors when:

- Yaml.parse type includes enums
- stringify.stringify type includes enums or bools