### PR TITLE
Fixed bug with literal parsing

### DIFF
--- a/src/Tokenizer.zig
+++ b/src/Tokenizer.zig
@@ -284,11 +284,11 @@ pub fn next(self: *Tokenizer) Token {
             },
 
             .literal => switch (c) {
-                '\r', '\n', ' ', '\'', '"', ']', '}' => {
+                '\r', '\n', ' ' => {
                     result.id = .literal;
                     break;
                 },
-                ',', '[', '{' => {
+                ',', '[', '{', ']', '}' => {
                     result.id = .literal;
                     if (self.in_flow > 0) {
                         break;

--- a/src/Tokenizer.zig
+++ b/src/Tokenizer.zig
@@ -284,11 +284,11 @@ pub fn next(self: *Tokenizer) Token {
             },
 
             .literal => switch (c) {
-                '\r', '\n', ' ' => {
+                '\r', '\n' => {
                     result.id = .literal;
                     break;
                 },
-                ',', '[', '{', ']', '}' => {
+                ',', '[', '{', '}', ']' => {
                     result.id = .literal;
                     if (self.in_flow > 0) {
                         break;


### PR DESCRIPTION
# Bug fix tokenizing literals

Bug fix for issue raised in https://github.com/kubkon/zig-yaml/issues/87 regarding strings terminating early due to internal quotation marks. this change passes all tests including the test included in the issue. I have not included the additional test in this PR.

The small fix involves removing some terminator characters that should only be relevant before the literal begins, not during. String handling is dealt with elsewhere and should not be relevant once we are dealing with a literal. Closing braces are moved to the case where in_flow is checked before breaking as I think this is the intended logic.

## current behavior
```
test: I'm great
```
this is currently parsed as 
```
test: I
```

## new behavior
```
test: I'm great
```
this is now parsed as
```
test: I'm great
```
