### PR TITLE
Fix parsing comment after list.

### DIFF
--- a/examples/yaml.zig
+++ b/examples/yaml.zig
@@ -5,7 +5,7 @@ const Yaml = @import("yaml").Yaml;
 
 const mem = std.mem;
 
-var gpa_alloc = std.heap.GeneralPurposeAllocator(.{}){};
+var gpa_alloc = std.heap.DebugAllocator(.{}){};
 const gpa = gpa_alloc.allocator();
 
 const usage =

--- a/src/Parser.zig
+++ b/src/Parser.zig
@@ -425,7 +425,7 @@ fn listBracketed(self: *Parser, gpa: Allocator) ParseError!Node.OptionalIndex {
         try values.append(gpa, .{ .node = value_index.unwrap().? });
     };
 
-    if (self.eatToken(.comment, &.{.comment})) |pos| {
+    if (self.eatToken(.comment, &.{ .comment, .new_line, .space })) |pos| {
         return self.fail(gpa, pos, "comments must be separated from other tokens by white space characters", .{});
     }
 

--- a/test/spec.zig
+++ b/test/spec.zig
@@ -97,7 +97,8 @@ fn make(step: *Step, make_options: Step.MakeOptions) !void {
     defer arena_allocator.deinit();
     const arena = arena_allocator.allocator();
 
-    var testcases = std.StringArrayHashMap(Testcase).init(arena);
+    // var testcases = std.StringArrayHashMap(Testcase).init(arena);
+    var testcases = std.StringArrayHashMapUnmanaged(Testcase).empty;
 
     const root_data_path = try fs.path.join(arena, &[_][]const u8{
         b.build_root.path.?,
@@ -168,7 +169,7 @@ fn make(step: *Step, make_options: Step.MakeOptions) !void {
     try man.writeManifest();
 }
 
-fn collectTest(io: std.Io, arena: Allocator, entry: std.Io.Dir.Walker.Entry, testcases: *std.StringArrayHashMap(Testcase)) !void {
+fn collectTest(io: std.Io, arena: Allocator, entry: std.Io.Dir.Walker.Entry, testcases: *std.StringArrayHashMapUnmanaged(Testcase)) !void {
     var path_components_it = std.fs.path.componentIterator(entry.path);
     const first_path = path_components_it.first().?;
 
@@ -178,7 +179,7 @@ fn collectTest(io: std.Io, arena: Allocator, entry: std.Io.Dir.Walker.Entry, tes
     }
 
     const remaining_path = try fs.path.join(arena, path_components.items);
-    const result = try testcases.getOrPut(remaining_path);
+    const result = try testcases.getOrPut(arena, remaining_path);
 
     var buffer: [256]u8 = undefined;
 


### PR DESCRIPTION
This PR excludes newlines and spaces when checking for comment after closing bracket in a list. Previously, YAML source text like this:
```yaml
alist: [1, 2] # A comment
```
or:
```yaml
alist: [1, 2] 
# A comment
```
would cause a ParseFailure as the parser would skip over the space or newline between the closing bracket and the comment. My understanding is that this should be legal YAML. Not skipping over spaces/newlines fixes this issue.

Let me know if I should add any tests or make any changes to the PR!