### PR TITLE
Fix error when compiling with -Dlog.

### DIFF
--- a/examples/yaml.zig
+++ b/examples/yaml.zig
@@ -16,7 +16,7 @@ const usage =
     \\
 ;
 
-var log_scopes: std.ArrayList([]const u8) = std.ArrayList([]const u8).init(gpa.allocator());
+var log_scopes: std.ArrayList([]const u8) = .empty;
 
 fn logFn(
     comptime level: std.log.Level,
@@ -78,7 +78,7 @@ pub fn main() !void {
             if (!build_options.enable_logging) {
                 try stderr.writeAll("warn: --debug-log will have no effect as program was not built with -Dlog\n\n");
             } else {
-                try log_scopes.append(args[arg_index]);
+                try log_scopes.append(allocator, args[arg_index]);
             }
         } else {
             file_path = args[arg_index];


### PR DESCRIPTION
New ArrayList interface requires passing allocator to calls to append. It appears that the code that is enabled when the -Dlog flag is passed to `zig build` was not updated to use the new interface. 

As a side note, `./zig-out/bin/yaml test/simple.yaml` seems to not work anymore and crashes within the call to Yaml.stringify(...), which occurs at line 110 of examples/yaml.zig.