### PR TITLE
Fix panic on empty mapping value at EOF

### DIFF
--- a/src/Parser.zig
+++ b/src/Parser.zig
@@ -168,6 +168,10 @@ fn value(self: *Parser, gpa: Allocator) ParseError!Node.OptionalIndex {
             self.token_it.seekBy(-1);
             return self.listBracketed(gpa);
         },
+        .eof => {
+            self.token_it.seekTo(pos);
+            return .none;
+        },
         else => return .none,
     }
 }

--- a/src/Parser/test.zig
+++ b/src/Parser/test.zig
@@ -878,6 +878,13 @@ test "empty map" {
     );
 }
 
+test "empty map value at eof" {
+    try parseSuccess(
+        \\key:
+        \\
+    );
+}
+
 test "comment within a bracketed list is an error" {
     try parseError(
         \\[ # something


### PR DESCRIPTION
This fixes a crash when parsing an entry with an empty value at end-of-file.

The parser consumes the `.eof` token while returning `.none`, leaving `token_it.pos` past the end of the token buffer. Later, in `Parser.map()` the `Parser.getCol()` causes the OOB access.

This should be valid YAML and pass:

```zig
test "empty map value at eof" {
    try parseSuccess(
        \\key:
        \\
    );
}
```