### PR TITLE
Fix parsing comment/newline after map scalar value

### DIFF
--- a/src/Parser.zig
+++ b/src/Parser.zig
@@ -537,7 +537,7 @@ fn leafValue(self: *Parser, gpa: Allocator) ParseError!Node.OptionalIndex {
             .literal => {},
             .space => {
                 const trailing = @intFromEnum(self.token_it.pos) - 2;
-                self.eatCommentsAndSpace(&.{});
+                self.eatCommentsAndSpace(&.{.comment, .new_line});
                 if (self.token_it.peek()) |peek| {
                     if (peek.id != .literal) {
                         const node_end: Token.Index = @enumFromInt(trailing);

--- a/src/Parser/test.zig
+++ b/src/Parser/test.zig
@@ -146,6 +146,60 @@ test "leaf in quotes" {
     try expectStringValueMapEntry(tree, entry_data.data, "key3", "double quoted");
 }
 
+test "white space after value" {
+//     testing.log_level = .debug;
+    const source =
+        \\key0: 0 
+        \\key1: 1 1
+        \\key2: 2 # with comment
+        \\key3: 3#this is not comment
+    ;
+
+    var parser = try Parser.init(testing.allocator, source);
+    defer parser.deinit(testing.allocator);
+    parser.parse(testing.allocator) catch |err| {
+        var bundle = try parser.errors.toOwnedBundle("");
+        defer bundle.deinit(testing.allocator);
+        var buf: std.Io.Writer.Allocating = .init(testing.allocator);
+        defer buf.deinit();
+        try bundle.renderToWriter(.{}, &buf.writer);
+        std.debug.print("detail: {s}", .{buf.written()});
+        return err;
+    };
+    var tree = try parser.toOwnedTree(testing.allocator);
+    defer tree.deinit(testing.allocator);
+
+    try testing.expectEqual(1, tree.docs.len);
+
+    const doc = tree.docs[0];
+    try testing.expectEqual(.doc, tree.nodeTag(doc));
+
+    try expectNodeScope(tree, doc, 0, tree.tokens.len - 2);
+
+    const doc_value = tree.nodeData(doc).maybe_node;
+    try testing.expect(doc_value != .none);
+    try testing.expectEqual(.map_many, tree.nodeTag(doc_value.unwrap().?));
+
+    const map = doc_value.unwrap().?;
+
+    try expectNodeScope(tree, map, 0, tree.tokens.len - 2);
+
+    const map_data = tree.extraData(Map, tree.nodeData(map).extra);
+    try testing.expectEqual(4, map_data.data.map_len);
+
+    var entry_data = tree.extraData(Map.Entry, map_data.end);
+    try expectValueMapEntry(tree, entry_data.data, "key0", "0");
+
+    entry_data = tree.extraData(Map.Entry, entry_data.end);
+    try expectValueMapEntry(tree, entry_data.data, "key1", "1 1");
+
+    entry_data = tree.extraData(Map.Entry, entry_data.end);
+    try expectValueMapEntry(tree, entry_data.data, "key2", "2");
+
+    entry_data = tree.extraData(Map.Entry, entry_data.end);
+    try expectValueMapEntry(tree, entry_data.data, "key3", "3#this is not comment");
+}
+
 test "nested maps" {
     const source =
         \\key1:

--- a/src/Tokenizer.zig
+++ b/src/Tokenizer.zig
@@ -377,7 +377,7 @@ test "empty doc with explicit markers and a directive" {
 test "sequence of values" {
     try testExpected(
         \\- 0
-        \\- 1
+        \\- 1 
         \\- 2
     , &[_]Token.Id{
         .seq_item_ind,
@@ -385,6 +385,7 @@ test "sequence of values" {
         .new_line,
         .seq_item_ind,
         .literal,
+        .space,
         .new_line,
         .seq_item_ind,
         .literal,
@@ -421,12 +422,19 @@ test "sequence of sequences" {
 test "mappings" {
     try testExpected(
         \\key1: value1
-        \\key2: value2
+        \\key2: value2 
+        \\key3: value3
     , &[_]Token.Id{
         .literal,
         .map_value_ind,
         .space,
         .literal,
+        .new_line,
+        .literal,
+        .map_value_ind,
+        .space,
+        .literal,
+        .space,
         .new_line,
         .literal,
         .map_value_ind,
@@ -573,7 +581,10 @@ test "comments" {
         \\- val1
         \\# second value
         \\- val2
+        \\key1: 1 # this is comment # and comment continue
+        \\key2: 2# this is not comment
     , &[_]Token.Id{
+        // key
         .literal,
         .map_value_ind,
         .space,
@@ -587,6 +598,28 @@ test "comments" {
         .comment,
         .new_line,
         .seq_item_ind,
+        .literal,
+        .new_line,
+        // key1
+        .literal,
+        .map_value_ind,
+        .space,
+        .literal,
+        .space,
+        .comment,
+        .new_line,
+        // key 2
+        .literal,
+        .map_value_ind,
+        .space,
+        .literal,
+        .space,
+        .literal,
+        .space,
+        .literal,
+        .space,
+        .literal,
+        .space,
         .literal,
         .eof,
     });


### PR DESCRIPTION
## About

The following YAML inputs were not parsed correctly.

```
# Trailing space after value
key: 0 

# Inline comment
key: 0 # with comment
```

So I fixed it and added some test cases.

## Notes

This is a companion fix to #116, which addresses the same issue in listBracketed() for flow sequences ([1, 2] # comment).