### PR TITLE
chore: migrate to array_hash_map.string -- see zig #31793

### DIFF
--- a/test/spec.zig
+++ b/test/spec.zig
@@ -97,7 +97,7 @@ fn make(step: *Step, make_options: Step.MakeOptions) !void {
     defer arena_allocator.deinit();
     const arena = arena_allocator.allocator();
 
-    var testcases = std.StringArrayHashMap(Testcase).init(arena);
+    var testcases = std.array_hash_map.String(Testcase).empty;
 
     const root_data_path = try fs.path.join(arena, &[_][]const u8{
         b.build_root.path.?,
@@ -168,7 +168,7 @@ fn make(step: *Step, make_options: Step.MakeOptions) !void {
     try man.writeManifest();
 }
 
-fn collectTest(io: std.Io, arena: Allocator, entry: std.Io.Dir.Walker.Entry, testcases: *std.StringArrayHashMap(Testcase)) !void {
+fn collectTest(io: std.Io, arena: Allocator, entry: std.Io.Dir.Walker.Entry, testcases: *std.array_hash_map.String(Testcase)) !void {
     var path_components_it = std.fs.path.componentIterator(entry.path);
     const first_path = path_components_it.first().?;
 
@@ -178,7 +178,7 @@ fn collectTest(io: std.Io, arena: Allocator, entry: std.Io.Dir.Walker.Entry, tes
     }
 
     const remaining_path = try fs.path.join(arena, path_components.items);
-    const result = try testcases.getOrPut(remaining_path);
+    const result = try testcases.getOrPut(arena, remaining_path);
 
     var buffer: [256]u8 = undefined;
 


### PR DESCRIPTION
just pulled latest zig since I saw that 0.16.0 got tagged, 

was seeing the following:

```
zig-pkg/zig_yaml-0.3.0-C1161vSrAgCEKLk0825Y_GtmnThQI6O_cqtkBHb57KT-/test/spec.zig:100:24: error: root source file struct 'std' has no member named 'StringArrayHashMap'
    var testcases = std.StringArrayHashMap(Testcase).init(arena);
                    ~~~^~~~~~~~~~~~~~~~~~~
/Users/carl/.zvm/master/lib/std/std.zig:1:1: note: struct declared here
pub const AutoHashMap = hash_map.AutoHashMap;
^~~
referenced by:
    create: zig-pkg/zig_yaml-0.3.0-C1161vSrAgCEKLk0825Y_GtmnThQI6O_cqtkBHb57KT-/test/spec.zig:59:92
    build: zig-pkg/zig_yaml-0.3.0-C1161vSrAgCEKLk0825Y_GtmnThQI6O_cqtkBHb57KT-/build.zig:61:36
    11 reference(s) hidden; use '-freference-trace=13' to see all references
```

the StringArrayHashMap was moved/deprecated in [zig #31793](https://codeberg.org/ziglang/zig/pulls/31793/files)

```
❮ zig version
0.16.0-dev.3153+d6f43caad
❮ zig build test
❮
```