### PR TITLE
Fix compilation for Zig 0.16.0

### DIFF
--- a/examples/yaml.zig
+++ b/examples/yaml.zig
@@ -5,9 +5,6 @@ const Yaml = @import("yaml").Yaml;
 
 const mem = std.mem;
 
-var gpa_alloc = std.heap.GeneralPurposeAllocator(.{}){};
-const gpa = gpa_alloc.allocator();
-
 const usage =
     \\Usage: yaml <path-to-yaml>
     \\
@@ -55,19 +52,18 @@ fn logFn(
 
 pub const std_options: std.Options = .{ .logFn = logFn };
 
-pub fn main(init: std.process.Init.Minimal) !void {
-    var arena_alloc = std.heap.ArenaAllocator.init(gpa);
-    defer arena_alloc.deinit();
-    const arena = arena_alloc.allocator();
+pub fn main(init: std.process.Init) !void {
+    const gpa = init.gpa;
+    const arena = init.arena.allocator();
 
     var threaded: std.Io.Threaded = .init(gpa, .{
-        .argv0 = .init(init.args),
-        .environ = init.environ,
+        .argv0 = .init(init.minimal.args),
+        .environ = init.minimal.environ,
     });
     defer threaded.deinit();
     const io = threaded.io();
 
-    const all_args = try init.args.toSlice(arena);
+    const all_args = try init.minimal.args.toSlice(arena);
     const args = all_args[1..];
 
     var stdout_buffer: [1024]u8 = undefined;

--- a/test/spec.zig
+++ b/test/spec.zig
@@ -97,7 +97,7 @@ fn make(step: *Step, make_options: Step.MakeOptions) !void {
     defer arena_allocator.deinit();
     const arena = arena_allocator.allocator();
 
-    var testcases = std.StringArrayHashMap(Testcase).init(arena);
+    var testcases: std.StringArrayHashMapUnmanaged(Testcase) = .empty;
 
     const root_data_path = try fs.path.join(arena, &[_][]const u8{
         b.build_root.path.?,
@@ -168,7 +168,7 @@ fn make(step: *Step, make_options: Step.MakeOptions) !void {
     try man.writeManifest();
 }
 
-fn collectTest(io: std.Io, arena: Allocator, entry: std.Io.Dir.Walker.Entry, testcases: *std.StringArrayHashMap(Testcase)) !void {
+fn collectTest(io: std.Io, arena: Allocator, entry: std.Io.Dir.Walker.Entry, testcases: *std.StringArrayHashMapUnmanaged(Testcase)) !void {
     var path_components_it = std.fs.path.componentIterator(entry.path);
     const first_path = path_components_it.first().?;
 
@@ -178,7 +178,7 @@ fn collectTest(io: std.Io, arena: Allocator, entry: std.Io.Dir.Walker.Entry, tes
     }
 
     const remaining_path = try fs.path.join(arena, path_components.items);
-    const result = try testcases.getOrPut(remaining_path);
+    const result = try testcases.getOrPut(arena, remaining_path);
 
     var buffer: [256]u8 = undefined;
 


### PR DESCRIPTION
**Summary**
Minimal changes to support std library changes in **Zig 0.16.0**.

**Key Changes**
* **Main Entry:** Changed `main` to use `std.process.Init` instead of `std.process.Init.Minimal`.
* **Subsystems:** Updated `std.Io.Threaded` and argument handling to use `init.minimal`.
* **Data Structures:** Converted `StringArrayHashMap` to `Unmanaged` variants in tests to follow new std patterns.