### PR TITLE
Fix test/spec.zig compile error due to StringArrayHashMap

### DIFF
--- a/test/spec.zig
+++ b/test/spec.zig
@@ -97,7 +97,7 @@ fn make(step: *Step, make_options: Step.MakeOptions) !void {
     defer arena_allocator.deinit();
     const arena = arena_allocator.allocator();
 
-    var testcases = std.StringArrayHashMap(Testcase).init(arena);
+    var testcases = try std.array_hash_map.String(Testcase).init(arena, &.{}, &.{});
 
     const root_data_path = try fs.path.join(arena, &[_][]const u8{
         b.build_root.path.?,
@@ -168,7 +168,7 @@ fn make(step: *Step, make_options: Step.MakeOptions) !void {
     try man.writeManifest();
 }
 
-fn collectTest(io: std.Io, arena: Allocator, entry: std.Io.Dir.Walker.Entry, testcases: *std.StringArrayHashMap(Testcase)) !void {
+fn collectTest(io: std.Io, arena: Allocator, entry: std.Io.Dir.Walker.Entry, testcases: *std.array_hash_map.String(Testcase)) !void {
     var path_components_it = std.fs.path.componentIterator(entry.path);
     const first_path = path_components_it.first().?;
 
@@ -178,7 +178,7 @@ fn collectTest(io: std.Io, arena: Allocator, entry: std.Io.Dir.Walker.Entry, tes
     }
 
     const remaining_path = try fs.path.join(arena, path_components.items);
-    const result = try testcases.getOrPut(remaining_path);
+    const result = try testcases.getOrPut(arena, remaining_path);
 
     var buffer: [256]u8 = undefined;
 


### PR DESCRIPTION
Found on zig 0.16:

```
$ zig version
0.16.0
$ zig build test
test/spec.zig:100:24: error: root source file struct 'std' has no member named 'StringArrayHashMap'
    var testcases = std.StringArrayHashMap(Testcase).init(arena);
                    ~~~^~~~~~~~~~~~~~~~~~~
/Users/thanabodee/compilers/zig/lib/std/std.zig:1:1: note: struct declared here
pub const AutoHashMap = hash_map.AutoHashMap;
^~~
referenced by:
    create: test/spec.zig:59:92
    build: build.zig:61:36
    6 reference(s) hidden; use '-freference-trace=8' to see all references
```

So this changes convert it to `std.array_has_map.String` and fix compile error after changing.

Tested by run `zig build test` and has no issue.