### PR TITLE
fix: restore Zig 0.16 compatibility in spec test generator

### DIFF
--- a/test/spec.zig
+++ b/test/spec.zig
@@ -97,7 +97,7 @@ fn make(step: *Step, make_options: Step.MakeOptions) !void {
     defer arena_allocator.deinit();
     const arena = arena_allocator.allocator();
 
-    var testcases = std.StringArrayHashMap(Testcase).init(arena);
+    var testcases = std.StringArrayHashMapUnmanaged(Testcase){};
 
     const root_data_path = try fs.path.join(arena, &[_][]const u8{
         b.build_root.path.?,
@@ -168,7 +168,7 @@ fn make(step: *Step, make_options: Step.MakeOptions) !void {
     try man.writeManifest();
 }
 
-fn collectTest(io: std.Io, arena: Allocator, entry: std.Io.Dir.Walker.Entry, testcases: *std.StringArrayHashMap(Testcase)) !void {
+fn collectTest(io: std.Io, arena: Allocator, entry: std.Io.Dir.Walker.Entry, testcases: *std.StringArrayHashMapUnmanaged(Testcase)) !void {
     var path_components_it = std.fs.path.componentIterator(entry.path);
     const first_path = path_components_it.first().?;
 
@@ -178,7 +178,7 @@ fn collectTest(io: std.Io, arena: Allocator, entry: std.Io.Dir.Walker.Entry, tes
     }
 
     const remaining_path = try fs.path.join(arena, path_components.items);
-    const result = try testcases.getOrPut(remaining_path);
+    const result = try testcases.getOrPut(arena, remaining_path);
 
     var buffer: [256]u8 = undefined;
 


### PR DESCRIPTION
On Zig 0.16.0, `zig build test` fails on `main` before running anything:

```
test/spec.zig:100:24: error: root source file struct 'std' has no member named 'StringArrayHashMap'
    var testcases = std.StringArrayHashMap(Testcase).init(arena);
```

`std.StringArrayHashMap` was removed in Zig 0.16 — only the `Unmanaged` variants remain (`std.StringArrayHashMapUnmanaged = array_hash_map.String`). Because `build.zig` imports `test/spec.zig` unconditionally at the top, the build script itself fails to compile, so **no** build step can run — including plain `zig build test` — regardless of `-Denable-spec-tests`.

`build.zig.zon` already declares `.minimum_zig_version = "0.16.0"`, so this is just leftover pre-0.16 API usage.

## Change

Three lines in `test/spec.zig`: switch to `StringArrayHashMapUnmanaged` and pass the arena to `getOrPut`. The map was already arena-backed, so there is no ownership or lifetime change and nothing needs a `deinit`.

## Verification

On zig 0.16.0:

- `zig build test` → exit 0
- `zig build test -Denable-spec-tests=true` → exit 0 (with the `yaml-test-suite` submodule checked out, so the patched `make`/`collectTest` path actually executes and generates the manifest)